### PR TITLE
✨ Discord Notification

### DIFF
--- a/bqckup.cnf.example
+++ b/bqckup.cnf.example
@@ -9,8 +9,19 @@ password="bqckup"
 [bqckup]
 ; Backup the configuration
 config_backup=1
+
 ; Default storage name
 root_folder_name=bqckup
 
 ; To understand how Bqckup performs in various environments by contributing anonymous statistics. This will enable us to identify any issues that may occur with specific distributions or setups and improve our analysis of the data.
 anonymous_statistic=1
+
+[notification]
+; Enable or disable notification
+enabled=0
+
+; Currently Only Discord is supported
+channel=discord
+
+; Webhook URL
+discord_webhook_url=

--- a/constant/__init__.py
+++ b/constant/__init__.py
@@ -13,7 +13,7 @@ SITE_CONFIG_PATH=path.join(BQ_PATH, 'sites')
 CONFIG_PATH=path.join(BQ_PATH, 'bqckup.cnf')
 
 # Bqckup Information
-VERSION="1.2.3"
+VERSION="1.2.4"
 
 # YOURLS Credentials
 YOURLS_HOST=""

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -3,6 +3,15 @@ from os import path
 from datetime import date, datetime
 from pathlib import Path
 
+
+def get_server_ip():
+    try:
+        result = requests.get('http://ifconfig.me', verify=False)
+        return result.text.strip()
+    except Exception as e:
+        import socket
+        return socket.gethostbyname(socket.gethostname())
+
 """
     all format with linux
     for example ( converted date )
@@ -137,7 +146,7 @@ def getInt(s):
     return int(arr[0])
 
 def get_today(format="%d-%B-%Y"):
-    return date.today().strftime(format)
+    return datetime.today().strftime(format)
 
 
 def getOlderFiles(path, fromDays):

--- a/lib/notifications/discord.py
+++ b/lib/notifications/discord.py
@@ -1,0 +1,19 @@
+import requests as req
+from classes.config import Config
+
+sender = {
+    "content": "",
+    "username" :"Bqckup Notification",
+    "avatar_url": "https://avatars.githubusercontent.com/u/108687982?s=48&v=4"
+}
+
+def send_notification(data):
+    try:
+        data = {**sender, **data}
+        req.post(Config().read('notification', 'discord_webhook_url'), json=data)        
+    except Exception as e:
+        print(f"Failed to send notification{e}")
+        
+        
+# if __name__ == "__main__":
+    # send_notification({"embeds": [{"title": "Bqckup Failed", "description": "This is an automated notification to inform you that the bqckup has failed.", "color": 15548997, "fields": [{"name": "Server IP", "value": "127.0.0.1", "inline": True}, {"name": "Name", "value": "openjournaltheme.com", "inline": True}, {"name": "Date", "value": "22-03-2024", "inline":True}, {"name": "Details", "value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam euismod, nisl eget ultricies aliquam, nunc nisl ultricies nunc, nec ultricies nisl nisl nec nisl. Donec euismod, nisl eget ultricies aliquam, nunc nisl ultricies nunc, nec ultricies nisl nisl nec nisl. Donec euismod, nisl eget ultricies aliquam, nunc nisl ultricies nunc, nec ultricies nisl nisl nec nisl. Donec euismod, nisl eget ultricies aliquam, nunc nisl ultricies nunc, nec ultricies nisl nisl nec nisl. Donec euismod, nisl eget ultricies aliquam, nunc nisl ultricies nunc, nec ultricies nisl nisl nec nisl. Donec euismod, nisl eget ultricies aliquam, nunc nisl ultricies nunc, nec ultricies nisl nisl nec nisl. Donec euismod, nisl eget ultricies aliquam, nunc nisl ultricies nunc, nec ultricies nisl nisl nec nisl. Donec euismod, nisl eget ultricies aliquam, nunc nisl ultricies nunc, nec ultricies nisl nisl nec nisl. ", "inline": False}], "footer": {"text": "If this was a mistake, please create issue here: https://github.com/bqckup/bqckup"}}]})


### PR DESCRIPTION
## Description

If a backup fails, this notification will be sent.

## Configuration

To enable it, make sure to modify the `bqckup.cnf` file and insert the webhook URL into `discord_webhook_url`.

```conf
[notification]
; Enable or disable notification
enabled=1

; Currently Only Discord is supported
channel=discord

; Webhook URL
discord_webhook_url=https://discord-webhook.url
```

## Preview

![CleanShot 2024-01-23 at 9  24 37](https://github.com/bqckup/bqckup/assets/49790011/87a15de4-a459-49a6-b77b-29f5efe8f5a9)
