### PR TITLE
Change bytes_to into format_size

### DIFF
--- a/bqckup.py
+++ b/bqckup.py
@@ -54,7 +54,6 @@ def migrate():
 def summary(site = None):
     from rich.progress import Progress, SpinnerColumn, TextColumn
     from helpers.datetime import interval_in_number
-    from helpers import bytes_to
     from datetime import datetime
 
     bqckups = Bqckup().list()
@@ -106,8 +105,8 @@ def summary(site = None):
         print("\n================================================================\n")
         print(f"Backup Name                     : {backup['name']}")
         print(f"Last Backup                     : {last_modified.strftime('%d/%m/%Y %H:%M:%S')}")
-        print(f"Last backup file size and name  : {bytes_to('m', last_size)} mb ({last_folder}) ")
-        print(f"Total size of a bqckup          : {bytes_to('m', total_size)} mb")
+        print(f"Last backup file size and name  : {format_size( last_size)} ({last_folder}) ")
+        print(f"Total size of a bqckup          : {format_size( total_size)}")
         print(f"Total files                     : {backups['KeyCount']}")
         print(f"Storage Name                    : {backup['options']['storage']}")
         print(f"Schedule                        : {interval}")
@@ -121,7 +120,6 @@ def summary(site = None):
 def history(site = None, filter_latest_days : int = 7):
     from models.log import Log
     from datetime import datetime
-    from helpers import bytes_to
 
     # check if site is empty
     if site is None :
@@ -137,14 +135,7 @@ def history(site = None, filter_latest_days : int = 7):
                 status = "[red]Failed[/red]"
 
             last_backup = datetime.fromtimestamp(log.created_at).strftime('%d/%m/%Y %H:%M:%S')
-            if log.file_size >= 1e+9:
-                # if size is greater than 1 gb
-                size = f"{bytes_to('g', log.file_size)} GB"
-            elif log.file_size >= 1000000:
-                # if size is greater than 1 mb
-                size = f"{bytes_to('m', log.file_size)} MB"
-            else:
-                size = f"{bytes_to('k', log.file_size)} KB"
+            size = format_size(log.file_size)
             time_consume = log.time_consume
             file_name = log.file_path.split('/')[-1]
 

--- a/classes/report.py
+++ b/classes/report.py
@@ -1,7 +1,6 @@
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from lib.notifications.discord import send_notification
 from datetime import datetime
-from helpers import bytes_to
 from helpers.datetime import difference_in_days, interval_in_number, get_today
 from helpers.utility import split_list, isset
 from models.log import Log
@@ -15,6 +14,7 @@ from classes.config import Config
 import calendar
 from hashlib import sha256
 from models.notification_log import NotificationLog
+from humanfriendly import format_size
 
 class Report:
 
@@ -164,8 +164,8 @@ class Report:
                             {"name": "Bqckup Version", "value": VERSION, "inline": True},
                             {"name": "Storage", "value": storage, "inline": True},
                             {"name": "Total Site on config", "value": len(Bqckup().list()), "inline": True},
-                            {"name": "Total Size", "value": f"{bytes_to('m',total_size)} MB", "inline": True},
-                            {"name": "Largest Site Files", "value": f"{largest_backup.get('Key').split('/')[1]} ({bytes_to('m', largest_backup.get('Size'))} MB)", "inline": True},
+                            {"name": "Total Size", "value": f"{format_size(total_size)}", "inline": True},
+                            {"name": "Largest Site Files", "value": f"{largest_backup.get('Key').split('/')[1]} ({format_size( largest_backup.get('Size'))})", "inline": True},
                             {"name": "List site in storage", "value": message_list_site_in_storage, "inline": False},
                             {"name": "", "value": f"```ansi\n{self.YELLOW_ASTERISK} : Site is available in storage, but not in config\n{self.RED_ASTERISK} : Issue Found```", "inline": False},
                             # {"name": "Failed Site", "value": failed_site, "inline": True},


### PR DESCRIPTION
# Overview
We changed to format_size to dynamically classify byte sizes.

# Difference of using bytes_to and format_size
## Summary

### bytes_to
![image](https://github.com/user-attachments/assets/fcd376cf-1a46-477f-ab85-3d1047ad231b)

### format_size
![image](https://github.com/user-attachments/assets/fabaf2f1-292f-4f0c-8d75-d20344810038)

## History

### bytes_to
![image](https://github.com/user-attachments/assets/6aeac5dd-c8a7-451a-a6f9-f3b112d26dd2)

### format_size
![image](https://github.com/user-attachments/assets/eda56620-cf48-46a6-b55c-d23f3d543d40)
