### PR TITLE
[Feature] Multiple Database in Site

### DIFF
--- a/classes/bqckup.py
+++ b/classes/bqckup.py
@@ -2,7 +2,6 @@ import os, time, shutil, signal, sys
 import traceback
 from subprocess import CalledProcessError
 from typing import Any, Dict
-from requests import RequestException
 from classes.database import Database
 from classes.rustic import Rustic, RusticCheckError, RusticConfigError
 from classes.storage import Storage
@@ -108,16 +107,31 @@ class Bqckup:
                 for path in config.get('path'):
                     if not os.path.exists(path):
                         raise ConfigExceptions(f"Can't find {path}")
-                if config.get("database") and (config.get("database").get("enabled") or config.get("database").get("enable")):
-                    database_config = config.get('database')
-                    if database_config.get('type') not in Database().SUPPORTED_DATABASE:
-                        raise ConfigExceptions(f"Database type {database_config.get('type')} not supported")
-                    Database(type=database_config.get('type')).test_connection({
-                        "user": database_config.get('user'),
-                        "password": database_config.get('password'),
-                        "host": database_config.get('host'),
-                        "name": database_config.get('name')
+
+                if Rustic.is_enabled(config) and config.get("incremental", {}).get("password") is None:
+                    raise RusticConfigError("Password can't be empty")
+
+                databases = config.get("databases", [])
+
+                # For backward compatibility
+                database = config.get("database", {})
+                if database and (database.get("enabled") or database.get("enable")):
+                    databases.append(database)
+
+                for database in databases:
+                    if not (database.get("enabled") or database.get("enable")):
+                        continue
+                    if database.get("type") not in Database().SUPPORTED_DATABASE:
+                        raise ConfigExceptions(
+                            f"Database type {database.get('type')} not supported"
+                        )
+                    Database(type=database["type"]).test_connection({
+                        "user": database["user"],
+                        "password": database["password"],
+                        "host": database["host"],
+                        "name": database["name"],
                     })
+
                 if config.get('options').get('provider') == 's3':
                     Storage().get_storage_detail(config.get('options').get('storage'))
             return True
@@ -255,11 +269,7 @@ class Bqckup:
                     self.do_backup(backup)
                     continue
 
-                if (
-                    (incremental := backup.get("incremental"))
-                    and incremental is not None
-                    and (incremental.get("enabled") or incremental.get("enable"))
-                ):
+                if Rustic.is_enabled(backup):
                     self.incremental_backup(backup, keep_credential=keep_credential)
                 else:
                     self.do_backup(backup)
@@ -532,7 +542,7 @@ class Bqckup:
             )
 
         # Database backup
-        self.backup_database(site_config, _s3)
+        self.backup_databases(site_config, _s3)
 
         result = {}
         rustic = Rustic(site_config, storage_config)
@@ -655,8 +665,8 @@ class Bqckup:
                 with ProgressSpinner("sending data..."):
                     send_backup_summary(
                         domain=site_config["name"],
-                        total_size=result.get("total_size", -1),
-                        new_data=result.get("uploaded", 0),
+                        total_size=result.get("total_size", -1), # pyright: ignore[reportArgumentType]
+                        new_data=result.get("uploaded", 0), # pyright: ignore[reportArgumentType]
                         start_at=int(time_start),
                         finish_at=int(time.time()),
                         status=backup_status,
@@ -665,77 +675,137 @@ class Bqckup:
             except Exception as e:
                 print(f"Error while sending backup summary: {e}")
 
-    def backup_database(self, config: Dict, s3: s3 | None = None):
-        """
-        Returns:
-            Path: return path to exported database
-        """
+    def backup_databases(self, site_config: dict[str, Any], s3: s3):
+        databases = site_config.get("databases", [])
 
-        if not config.get("database") or not \
-            (config.get("database", {}).get("enabled") or \
-             config.get("database", {}).get("enable")):
+        # For backward compatibility
+        if site_config.get("database"):
+            database = site_config.get("database", {})
+            if database.get("enabled") or database.get("enable"):
+                databases.append(database)
+
+        if not databases:
             return
 
-        tmp_path: Path = Path(BQ_PATH) / "tmp" / config["name"]
-        backup_path = tmp_path / f"{int(time.time())}.sql.gz"
-        time_start = time.time()
+        should_save_locally: bool = site_config.get("options", {}).get("save_locally", False)
+        save_locally_path_str = site_config.get("options", {}).get("save_locally_path", "/etc/bqckup/tmp")
+        save_locally_path = Path(save_locally_path_str) if save_locally_path_str else None
 
-        current_log: Log = Log().write(
+        for database in databases:
+            if not (database.get("enabled") or database.get("enable")):
+                print(f"[yellow]Skipping disabled database: {database.get('name')}[/yellow]")
+                continue
+
+            self.backup_database(
+                site_config=site_config,
+                database=database,
+                s3=s3,
+                should_save_locally=should_save_locally,
+                save_locally_path=save_locally_path,
+            )
+
+    def backup_database(
+        self,
+        site_config: dict[str, Any],
+        database: dict[str, Any],
+        s3: s3 | None = None,
+        should_save_locally: bool = False,
+        save_locally_path: Path | None = None,
+    ):
+        db_label = f"{database['user']}@{database['host']}:{database['port']}/{database['name']}"
+
+        print(f"Starting database backup for {site_config['name']} {db_label}")
+
+        time_start = time.time()
+        tmp_path: Path = Path(BQ_PATH) / "tmp" / site_config["name"]
+        backup_path = tmp_path / f"{int(time_start)}-{database['name']}.sql.gz"
+
+        if not tmp_path.exists() or not tmp_path.is_dir():
+            tmp_path.mkdir(parents=True, exist_ok=True)
+
+        current_log = Log().write(
             {
-                "name": config["name"],
-                "description": "Database Backup is in Progress",
+                "name": site_config["name"],
+                "description": f"Database Backup for '{db_label}' in Progress",
                 "type": Log.__DATABASE__,
-                "storage": config["options"]["storage"],
-                "file_path": backup_path,
+                "storage": site_config["options"]["storage"],
+                "file_path": str(backup_path),
             }
         )
 
-        last_log = (
-            Log.select()
-            .where(
-                (Log.name == config["name"])
-                & (Log.type == Log.__DATABASE__)
-                & (Log.file_size != 0)
-            )
-            .order_by(Log.id.desc())
-            .get_or_none()
-        )
-
         try:
-            if not tmp_path.exists() or not tmp_path.is_dir():
-                tmp_path.mkdir(parents=True, exist_ok=True)
-
-            with ProgressSpinner("Exporting database"):
+            with ProgressSpinner(f"Exporting database {db_label}"):
                 Database().export(
-                    str(backup_path) if isinstance(backup_path, Path) else backup_path,
-                    db_user=config["database"]["user"],
-                    db_password=config["database"]["password"],
-                    db_name=config["database"]["name"],
+                    str(backup_path),
+                    db_user=database["user"],
+                    db_password=database["password"],
+                    db_name=database["name"],
                 )
 
             if s3:
                 s3.upload(
                     backup_path,
-                    Path(config["name"]) / get_today() / backup_path.name,
+                    Path(site_config["name"]) / get_today() / backup_path.name,
                 )
 
-            current_size = backup_path.stat().st_size
             Log.update(
-                file_size=current_size,
+                file_size=backup_path.stat().st_size,
                 status=Log.__SUCCESS__,
                 time_consume=time.time() - time_start,
-                description="Database Backup Success",
+                description=f"Database Backup for '{db_label}' Success",
             ).where(Log.id == current_log.id).execute()
 
-            #
+            # Refresh the log object to get the updated time_consume
+            current_log = Log.get_by_id(current_log.id)
 
+            self._post_database_backup(
+                site_name=site_config["name"],
+                db_label=db_label,
+                backup_path=backup_path,
+                current_log=current_log,
+                should_save_locally=should_save_locally,
+                save_locally_path=save_locally_path,
+            )
+        except Exception as e:
+            Log.update(
+                status=Log.__FAILED__,
+                time_consume=time.time() - time_start,
+                description=f"Database Backup Failed for '{db_label}'",
+            ).where(Log.id == current_log.id).execute()
+
+            print(f"failed to backup database {db_label}: {e}")
+
+            self._send_notification(
+                backup_name=site_config["name"],
+                title=f"Database Backup Failed for {site_config['name']} {db_label}",
+                messages=f"Error: {e}",
+            )
+
+    def _post_database_backup(
+        self,
+        site_name: str,
+        db_label: str,
+        backup_path: Path,
+        current_log: Log,
+        should_save_locally: bool = False,
+        save_locally_path: Path | None = None,
+    ) -> None:
+        last_log = Log.select().where(
+            (Log.name == site_name)
+            & (Log.type == Log.__DATABASE__)
+            & (Log.status == Log.__SUCCESS__)
+            & (Log.description.contains(db_label))
+        ).order_by(Log.id.desc()).get_or_none()
+
+        try:
             if last_log:
                 previous_size = format_size(last_log.file_size)
                 time_consume = format_timespan(current_log.time_consume)
-                current_size = format_size(current_size)
+                current_size = format_size(backup_path.stat().st_size)
 
                 print("=========================================")
                 print("Database Compressed")
+                print(f"Database\t: {db_label}")
                 print(f"Previous Size\t: {previous_size}")
                 print(f"Current Size\t: {current_size}")
                 print(f"Time Consumed\t: {time_consume}")
@@ -743,37 +813,21 @@ class Bqckup:
 
                 if previous_size == current_size:
                     print(
-                        f"[red]Based on file size, there is no changes detected for {backup_path}[/red]\n"
+                        f"[yellow]Based on file size, there is no changes detected for {backup_path.name}[/yellow]\n"
                     )
 
-            should_save_locally: bool = config.get("options", {}).get("save_locally")
-            save_locally_path = Path(
-                config.get("options", {}).get("save_locally_path", "/etc/bqckup/tmp")
-            )  # If not set it will be at /etc/bqckup/tmp
-
             if not should_save_locally:
-                backup_path.unlink(True)  # remove file
+                backup_path.unlink(missing_ok=True) # remove file
             elif should_save_locally and save_locally_path:
-                print("Saving locally ...")
-                save_locally_path: Path = save_locally_path / config["name"]
-                if not save_locally_path.is_dir():
-                    save_locally_path.mkdir(parents=True, exist_ok=True)
+                print(f"Saving '{backup_path.name}' locally ...")
+                final_dest_path: Path = save_locally_path / site_name
+                if not final_dest_path.is_dir():
+                    final_dest_path.mkdir(parents=True, exist_ok=True)
 
-                if backup_path.parent.resolve() != save_locally_path.resolve():
-                    print(f"Moving {backup_path} to {save_locally_path}...")
-                    shutil.move(backup_path, save_locally_path)
-
+                if backup_path.parent.resolve() != final_dest_path.resolve():
+                    print(f"Moving {backup_path} to {final_dest_path}...")
+                    shutil.move(backup_path, final_dest_path)
         except Exception as e:
-            Log.update(
-                status=Log.__FAILED__,
-                time_consume=time.time() - time_start,
-                description="Database Backup Failed",
-            ).where(Log.id == current_log.id).execute()
-
-            print(f"failed to backup database: {e}")
-
-            self._send_notification(
-                backup_name=config["name"],
-                title="Database Backup Failed",
-                messages=f"Error: {e}",
+            print(
+                f"Error while post-processing database backup for {site_name} '{db_label}': {e}"
             )

--- a/classes/bqckup.py
+++ b/classes/bqckup.py
@@ -254,13 +254,25 @@ class Bqckup:
                         continue
 
                 last_running_log = Log().select().where(
-                    Log.name == backup.get("name")
-                    and Log.status == Log.__ON_PROGRESS__
+                    (Log.name == backup.get("name"))
+                    & (Log.status == Log.__ON_PROGRESS__)
                 )
 
                 if last_running_log.exists():
                     print(f"Backup for {backup.get('name')} is already running...")
                     continue
+
+                _s3 = None
+                storage_name = backup.get("options", {}).get("storage")
+                if backup.get("options", {}).get("provider") == "s3" and storage_name:
+                    _s3 = s3(storage_name=storage_name)
+                    if Config().read('bqckup', 'config_backup'):
+                        print("Backing up config files...")
+                        config_path = Path(SITE_CONFIG_PATH) / backup["file_name"]
+                        _s3.upload(config_path, f"config/{backup.get('name')}.yml", False)
+                        _s3.upload(STORAGE_CONFIG_PATH, "storages.yml", False)
+
+                self.backup_databases(backup, _s3)
 
                 if backup_method == "incremental":
                     self.incremental_backup(backup, keep_credential=keep_credential)
@@ -283,11 +295,22 @@ class Bqckup:
     # Upload
     def do_backup(self, backup_config):
         time_start = time.time()
+        log_compressed_files = None
+        compressed_file_size = 0
+        summary_payload = {
+            "domain": backup_config.get("name"),
+            "total_size": 0,
+            "new_data": 0,
+            "start_at": int(time_start),
+            "finish_at": None,
+            "status": "failed",
+            "backup_method": "tar",
+        }
+
         try:
             bqckup_config_location = os.path.join(SITE_CONFIG_PATH, backup_config['file_name'])
             backup = Yml_Parser.parse(bqckup_config_location)['bqckup']
             backup_folder = f"{backup.get('name')}/{get_today()}"
-            
             tmp_path = os.path.join(BQ_PATH, 'tmp', f"{backup.get('name')}")
             
             if not File().is_exists(tmp_path):
@@ -309,6 +332,8 @@ class Bqckup:
             last_compressed_file_backup = Log().select().where((Log.name == backup.get('name')) & (Log.type == Log.__FILES__) & (Log.file_size != 0)).order_by(Log.id.desc()).get_or_none()
 
             compressed_file_size = os.stat(compressed_file).st_size
+            summary_payload["total_size"] = compressed_file_size
+            summary_payload["new_data"] = compressed_file_size
 
             if last_compressed_file_backup:
                 
@@ -349,42 +374,6 @@ class Bqckup:
 
             Log().update(file_size=os.stat(compressed_file).st_size).where(Log.id == log_compressed_files.id).execute()
             
-            sql_path = os.path.join(tmp_path, f"{int(time.time())}.sql.gz")
-            
-            if backup.get("database") and (backup.get("database").get("enabled") or backup.get("database").get("enable")):
-                with ProgressSpinner("Exporting database..."):
-                    log_database = Log().write({
-                        "name": backup['name'],
-                        "file_path": sql_path,
-                        "description": "Database Backup is in Progress",
-                        "type": Log.__DATABASE__,
-                        "storage": backup['options']['storage'],
-                    })
-                    Database().export(
-                        sql_path,
-                        db_user=backup.get('database').get('user'),
-                        db_password=backup.get('database').get('password'),
-                        db_name=backup.get('database').get('name'),
-                    )
-                    last_log_db_backup = Log().select().where((Log.name == backup.get('name')) & (Log.type == Log.__DATABASE__) & (Log.file_size != 0)).order_by(Log.id.desc()).get_or_none()
-                    
-                if last_log_db_backup:
-                    
-                    previous_size = format_size(last_log_db_backup.file_size)
-                    current_size = format_size(os.stat(sql_path).st_size)
-                    time_consume = format_timespan(last_log_db_backup.time_consume)
-                    print("=========================================")
-                    print("Database Compressed")
-                    print(f"Previous Size\t: {previous_size}")
-                    print(f"Current Size\t: {current_size}")
-                    print(f"Time Consumed\t: {time_consume}")
-                    print("=========================================")
-
-                if last_log_db_backup and os.stat(sql_path).st_size == last_log_db_backup.file_size:
-                    print(f"[red]Based on file size, there is no changes detected for {sql_path}[/red]\n")
-                
-                Log().update(file_size=os.stat(sql_path).st_size).where(Log.id == log_database.id).execute()
-            
             if backup.get('options').get('provider') == 'local':
                 destination = backup.get('options').get('destination')
                 backup_path = os.path.join(destination, backup_folder)
@@ -404,10 +393,6 @@ class Bqckup:
                 if os.path.exists(compressed_file):
                     shutil.move(compressed_file, os.path.join(backup_path, os.path.basename(compressed_file)))
                     Log().update_status(log_compressed_files.id, Log.__SUCCESS__, "File Backup Success", time_consume)
-                
-                if os.path.exists(sql_path):
-                    shutil.move(sql_path, os.path.join(backup_path, os.path.basename(sql_path)))
-                    Log().update_status(log_database.id, Log.__SUCCESS__, "Database Backup Success", time_consume)
                     
             if backup.get('options').get('provider') == 's3':
                 _s3 = s3(storage_name=backup.get('options').get('storage'))
@@ -444,23 +429,14 @@ class Bqckup:
                     )
                     time_consume = time.time() - time_start
                     Log().update_status(log_compressed_files.id, Log.__SUCCESS__, "File Backup Success", time_consume)
-                    
-                
-                if os.path.exists(sql_path):
-                    print(f"\nUploading {sql_path}")
-                    _s3.upload(
-                        sql_path,
-                        f"{backup_folder}/{os.path.basename(sql_path)}"
-                    )
-                    
+
                     should_save_locally = backup.get('options').get('save_locally')
                     save_locally_path = backup.get('options').get('save_locally_path') # If not set it will be at /etc/bqckup/tmp
                     
                     if not should_save_locally:
                         os.unlink(compressed_file)
-                        os.unlink(sql_path)
                     elif should_save_locally and save_locally_path:
-                        print("Saving locally ...")
+                        print("Saving file backup locally ...")
                         if not os.path.isdir(save_locally_path):
                             raise Exception(f"Save locally path {save_locally_path} is not a directory")
                         else:
@@ -469,30 +445,23 @@ class Bqckup:
                                 if not os.path.isdir(save_locally_path):
                                     os.makedirs(save_locally_path)
                                 shutil.move(compressed_file, save_locally_path)
-                                shutil.move(sql_path, save_locally_path)
                             except Exception as e:
-                                print(f"Failed to save locally: {e}")
-
-                    time_consume = time.time() - time_start
-                    Log().update_status(log_database.id, Log.__SUCCESS__, "Database Backup Success", time_consume)
+                                print(f"Failed to save file backup locally: {e}")
             
             print(f"\n[green]Backup for {backup.get('name')} is done![/green]")
-            backup_status = "completed"
+            summary_payload["status"] = "completed"
         except Exception as e:
-            backup_status = "failed"
+            summary_payload["status"] = "failed"
+
             import traceback
             traceback.print_exc()
 
             # If backup failed remove the tmp folder
             remove_folder(tmp_path)
 
-            # Separate this two error by it's own exceptions
             time_consume = time.time() - time_start
-            if 'log_compressed_files' in locals():
+            if log_compressed_files:
                 Log().update_status(log_compressed_files.id, Log.__FAILED__, f"File Backup Failed: {e}", time_consume)
-                
-            if 'log_database' in locals():
-                Log().update_status(log_database.id, Log.__FAILED__, f"Database Backup Failed: {e}", time_consume)
 
             self._send_notification(
                 backup.get("name"),
@@ -505,15 +474,8 @@ class Bqckup:
         finally:
             try:
                 with ProgressSpinner("sending data..."):
-                    send_backup_summary(
-                        domain=backup.get("name"),
-                        total_size=compressed_file_size,
-                        new_data=compressed_file_size,
-                        start_at=int(time_start),
-                        finish_at=int(time.time()),
-                        status=backup_status,
-                        backup_method="tar",
-                    )
+                    summary_payload["finish_at"] = int(time.time())
+                    send_backup_summary(**summary_payload)
             except Exception as e:
                 print(f"Error: {e}")
 
@@ -523,6 +485,15 @@ class Bqckup:
         keep_credential: bool = False,
     ) -> None:
         time_start = time.time()
+        summary_payload = {
+            "domain": site_config.get("name"),
+            "total_size": 0,
+            "new_data": 0,
+            "start_at": int(time_start),
+            "finish_at": None,
+            "status": "failed",
+            "backup_method": "incremental",
+        }
 
         if site_config.get("options", {}).get("provider") != "s3":
             raise RuntimeError("Currently, incremental backup only support S3 provider")
@@ -531,18 +502,7 @@ class Bqckup:
 
         bucket_name = site_config.get("options", {}).get("storage")
         storage_config = Storage().get_storage_detail(bucket_name)
-        _s3 = s3(storage_name=bucket_name)
 
-        if Config().read("bqckup", "config_backup"):
-            _s3.upload(STORAGE_CONFIG_PATH, "storages.yml", False)
-            _s3.upload(
-                Path(SITE_CONFIG_PATH) / site_config["file_name"],
-                f"config/{site_config.get('name')}.yml",
-                False,
-            )
-
-        # Database backup
-        self.backup_databases(site_config, _s3)
 
         result = {}
         rustic = Rustic(site_config, storage_config)
@@ -564,10 +524,13 @@ class Bqckup:
             with ProgressSpinner("doing incremental backup..."):
                 result = rustic.backup()
 
+            summary_payload["total_size"] = result.get("total_size", -1)
+            summary_payload["new_data"] = result.get("uploaded", 0)
+
             Log.update(
                 status=Log.__SUCCESS__,
                 time_consume=time.time() - time_start,
-                file_size=result["total_size"],
+                file_size=summary_payload["total_size"],
                 file_path=result["id"],  # rustic snapshots id
                 description="File Backup Success",
             ).where(Log.id == logs.id).execute()
@@ -582,7 +545,7 @@ class Bqckup:
             print("Time Consumed\t:", format_timespan(result["total_duration"]))
             print("=========================================")
 
-            backup_status = "completed"
+            summary_payload["status"] = "completed"
 
             with ProgressSpinner("checking repository..."):
                 rustic.check_repository()
@@ -615,7 +578,7 @@ class Bqckup:
             )
 
         except Exception as e:
-            backup_status = "failed"
+            summary_payload["status"] = "failed"
 
             if is_debug():
                 traceback.print_exc()
@@ -663,19 +626,15 @@ class Bqckup:
             rustic.dump_config(with_credentials=keep_credential)
             try:
                 with ProgressSpinner("sending data..."):
-                    send_backup_summary(
-                        domain=site_config["name"],
-                        total_size=result.get("total_size", -1), # pyright: ignore[reportArgumentType]
-                        new_data=result.get("uploaded", 0), # pyright: ignore[reportArgumentType]
-                        start_at=int(time_start),
-                        finish_at=int(time.time()),
-                        status=backup_status,
-                        backup_method="incremental",
-                    )
+                    summary_payload["finish_at"] = int(time.time())
+                    send_backup_summary(**summary_payload)
             except Exception as e:
                 print(f"Error while sending backup summary: {e}")
 
-    def backup_databases(self, site_config: dict[str, Any], s3: s3):
+    def backup_databases(self, site_config: dict[str, Any], s3: s3 | None):
+        if not s3:
+            return
+
         databases = site_config.get("databases", [])
 
         # For backward compatibility

--- a/classes/bqckup.py
+++ b/classes/bqckup.py
@@ -376,6 +376,9 @@ class Bqckup:
             
             if backup.get('options').get('provider') == 'local':
                 destination = backup.get('options').get('destination')
+                if not destination:
+                    raise Exception("'destination' path must be configured for local provider")
+
                 backup_path = os.path.join(destination, backup_folder)
                 
                 if not os.path.exists(backup_path):
@@ -502,7 +505,6 @@ class Bqckup:
 
         bucket_name = site_config.get("options", {}).get("storage")
         storage_config = Storage().get_storage_detail(bucket_name)
-
 
         result = {}
         rustic = Rustic(site_config, storage_config)
@@ -632,9 +634,6 @@ class Bqckup:
                 print(f"Error while sending backup summary: {e}")
 
     def backup_databases(self, site_config: dict[str, Any], s3: s3 | None):
-        if not s3:
-            return
-
         databases = site_config.get("databases", [])
 
         # For backward compatibility
@@ -649,6 +648,9 @@ class Bqckup:
         should_save_locally: bool = site_config.get("options", {}).get("save_locally", False)
         save_locally_path_str = site_config.get("options", {}).get("save_locally_path", "/etc/bqckup/tmp")
         save_locally_path = Path(save_locally_path_str) if save_locally_path_str else None
+
+        if not s3:
+            should_save_locally = True
 
         for database in databases:
             if not (database.get("enabled") or database.get("enable")):
@@ -772,7 +774,7 @@ class Bqckup:
 
                 if previous_size == current_size:
                     print(
-                        f"[yellow]Based on file size, there is no changes detected for {backup_path.name}[/yellow]\n"
+                        f"[yellow]Based on file size, there is no changes detected for {backup_path.name}[/yellow]"
                     )
 
             if not should_save_locally:
@@ -786,6 +788,10 @@ class Bqckup:
                 if backup_path.parent.resolve() != final_dest_path.resolve():
                     print(f"Moving {backup_path} to {final_dest_path}...")
                     shutil.move(backup_path, final_dest_path)
+                else:
+                    print(f"Database backup located at {backup_path}")
+
+            print()
         except Exception as e:
             print(
                 f"Error while post-processing database backup for {site_name} '{db_label}': {e}"

--- a/classes/rustic.py
+++ b/classes/rustic.py
@@ -79,7 +79,7 @@ class Rustic:
                 self.site_config["name"],
                 "--json",
             ],
-            **self.__subprocess_args,
+            **self.__subprocess_args,  # type: ignore
         )
 
         parsed_output = json.loads(output.stdout)
@@ -91,6 +91,11 @@ class Rustic:
         except Exception as e:
             raise RusticError("Error while getting snapshots:", e)
 
+    @staticmethod
+    def is_enabled(config: dict) -> bool:
+        incremental = config.get("incremental", {})
+        return incremental and (incremental.get("enabled") or incremental.get("enable"))
+
     def check_repository(self):
         try:
             subprocess.run(
@@ -100,7 +105,7 @@ class Rustic:
                     "--use-profile",
                     self.site_config["name"],
                 ],
-                **self.__subprocess_args,
+                **self.__subprocess_args,  # type: ignore
             )
         except subprocess.CalledProcessError as e:
             raise RusticCheckError(e.returncode, e.cmd, e.output, e.stderr)
@@ -123,7 +128,7 @@ class Rustic:
                 "--use-profile",
                 self.site_config["name"],
             ],
-            **self.__subprocess_args,
+            **self.__subprocess_args,  # type: ignore
         )
 
         if output.returncode != 0:
@@ -144,7 +149,7 @@ class Rustic:
             "total_size": summary["total_bytes_processed"],
         }
 
-    def restore(self, snapshot: str, target: str = None):
+    def restore(self, snapshot: str, target: str | None = None):
         """Restore backup
 
         Args:
@@ -168,14 +173,13 @@ class Rustic:
                 destination,
             ]  # command: rustic -P domain.com restore latest:/var/www/html /var/www/html
 
-            subprocess.run(command, **self.__subprocess_args)
+            subprocess.run(command, **self.__subprocess_args)  # type: ignore
             print(f"[OK] {path}")
 
     def check_config(self):
         """Check rustic configuration from sites
 
         Raises:
-            RusticConfigError: rustic not configured
             RusticConfigError: password empty
         """
 

--- a/helpers/utility.py
+++ b/helpers/utility.py
@@ -129,8 +129,5 @@ def isset(key, array = None):
     else:
         return key in globals()
 
-def get_env(key:str, default: str):
-    return os.environ.get(key, default=default)
-
 def is_debug():
-    return get_env('BQCKUP_DEBUG', "0") == "1"
+    return os.environ.get('BQCKUP_DEBUG', "0") == "1"

--- a/sites/domain.yml.example
+++ b/sites/domain.yml.example
@@ -16,6 +16,14 @@ bqckup:
     user: root
     password: root
     name: database
+  databases:
+    - enabled: yes
+      type: mysql
+      host: localhost
+      port: 3306
+      user: root
+      password: root
+      name: database
   options:
     storage: dummy
     interval: daily #can be daily, weekly, monthly 


### PR DESCRIPTION
## Multiple Database Config
```yaml
databases:
  - enabled: yes
    type: mysql
    host: 172.17.0.1
    port: 3307
    user: root
    password: root
    name: test_database
  - enabled: yes
    type: mysql
    host: 172.17.0.1
    port: 3308
    user: root
    password: root
    name: db2
```

## Note
- tested with Python 3.10.12 and rustic v0.9.5 musl
- old configuration keys under `database.*` are still supported.

## Development Environment with Distrobox
```toml
[bqckup]
image=ubuntu:22.04
root=false
init=false
start_now=true
unshare_all=true
home="~/.local/share/distrobox/bqckup"
additional_packages="micro libfuse2"
```