### PR TITLE
Keep Old Backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 __pycache__/
-venv/
+venv*/
 tmp/
 database/
 *.spec

--- a/classes/bqckup.py
+++ b/classes/bqckup.py
@@ -13,10 +13,11 @@ from classes.progress import ProgressSpinner
 from classes.yml_checker import Yml_Checker
 from classes.s3 import s3
 from helpers.hook import send_backup_summary
+from helpers.backup import get_backups_to_keep
 from helpers.utility import is_debug
 from models.log import Log
 from models.notification_log import NotificationLog
-from constant import BQ_PATH, STORAGE_CONFIG_PATH, SITE_CONFIG_PATH, MAX_RETRIES, BACKOFF
+from constant import BQ_PATH, STORAGE_CONFIG_PATH, SITE_CONFIG_PATH, MAX_RETRIES, BACKOFF, VERSION
 from datetime import datetime
 from helpers.file import remove_folder
 from hashlib import sha256
@@ -56,7 +57,6 @@ class Bqckup:
         description=None,
         messages=None,
         additional_data=None,
-        footer=None,
         color=15548997,
     ):
         fields = [
@@ -79,7 +79,7 @@ class Bqckup:
                     "color": color,
                     "fields": fields,
                     "footer": {
-                        "text": footer,
+                        "text": f"Bqckup v{VERSION}",
                     }
                 }
             ]
@@ -127,6 +127,10 @@ class Bqckup:
 
                 if config.get('options').get('provider') == 's3':
                     Storage().get_storage_detail(config.get('options').get('storage'))
+
+                if config.get("options").get("provider") == "local" and \
+                    not config.get("options").get("destination"):
+                    raise Exception("'destination' path must be configured for local provider")
             return True
         except Exception as e:
             print(f"[red]Error: {e}[/red]")
@@ -171,41 +175,80 @@ class Bqckup:
     def get_logs(self, name: str):
         return list(Log().select().where(Log.name == name))
 
-    def _clean_old_backups(self, backup_config: Dict[str, Any]) -> None:
+    def _clean_old_backups(self, site_config: Dict[str, Any]) -> None:
         print("Removing old backups...")
 
         try:
-            _s3 = s3(storage_name=backup_config.get("options", {}).get("storage"))
-            site_name: str = backup_config.get("name", "")
-            keep_last = int(backup_config.get("options", {}).get("retention", 3))
+            _s3 = s3(storage_name=site_config.get("options", {}).get("storage"))
+            base_prefix = Config().read("bqckup", "root_folder_name") or "bqckup"
+            site_name: str = site_config.get("name", "")
+            retentions = site_config.get("options", {}).get("keep", {})
 
-            backup_dates = _s3.get_backup_dates(site_name=site_name, sort_by_date=True)
-            backup_to_delete = backup_dates[:-keep_last]
+            backup_dates = _s3.get_backup_dates(
+                site_name=site_name, sort_by_date=False, with_prefix=False
+            )
+
+            if not backup_dates:
+                print("No backups found to remove.")
+                return
+
+            policy = {
+                "daily": int(retentions.get("daily")),
+                "weekly": int(retentions.get("weekly")),
+                "monthly": int(retentions.get("monthly")),
+            }
+
+            if not retentions:
+                policy["daily"] = site_config.get("options", {}).get("retention", 7)
+
+            dates = []
+            for date in backup_dates:
+                try:
+                    dates.append(datetime.strptime(date, "%d-%B-%Y"))
+                except (ValueError, IndexError) as e:
+                    print(f"[yellow]Warning: Could not parse date {e}. Skipping.[/yellow]")
+
+            if not dates:
+                print("No valid backup dates found to apply policy.")
+                return
+
+            dates_to_keep = get_backups_to_keep(dates, policy)
+            backup_to_delete = {
+                date.strftime("%d-%B-%Y")
+                for date in dates
+                if date not in dates_to_keep
+            }
 
             if not backup_to_delete:
                 print("No old backup to delete")
+                if dates_to_keep:
+                    print(f"{len(dates_to_keep)} backups are being kept.")
                 return
 
             objects = [
                 obj.get("Key")
                 for prefix in backup_to_delete
-                for obj in _s3.list(prefix=prefix).get("Contents", [])
+                for obj in _s3.list(prefix=f"{base_prefix}/{site_name}/{prefix}").get("Contents", [])
                 if obj.get("Key")
             ]
 
-            _s3.delete_objects(objects=objects)
+            if objects:
+                _s3.delete_objects(objects=objects)
+                print(f"Deleted {len(objects)} objects from {len(backup_to_delete)} old backups.")
+            else:
+                print("No objects found to delete for the specified backup dates.")
 
         except Exception as e:
             if is_debug():
                 traceback.print_exc()
 
-            err_msg = f"Failed to Clean Old Backups for {backup_config.get('name')}"
+            err_msg = f"Failed to Clean Old Backups for {site_config.get('name')}"
             print(f"[red]Error: {err_msg}.[/red]")
             self._send_notification(
-                backup_name=backup_config.get("name"),
+                backup_name=site_config.get("name"),
                 title=err_msg,
                 description=f"An error occurred while trying to clean old backups.\n\n**Error:**\n```{e}```",
-                color=15158332,  # Red color
+                color=15158332,  # red
             )
 
     def _should_skip_backup(self, backup: Dict[str, Any], force: bool) -> bool:
@@ -275,10 +318,7 @@ class Bqckup:
         site: Optional[str] = None,
         incremental: Optional[bool] = None,
     ):
-        if site:
-            backups = {0: self.detail(site)}
-        else:
-            backups = self.list()
+        backups = {0: self.detail(site)} if site else self.list()
 
         if not backups:
             print("No backups found")
@@ -287,12 +327,16 @@ class Bqckup:
         valid_backups = {}
         for k, v in backups.items():
             try:
-                if self.validate_config(v['name']):
+                if self.validate_config(v["name"]):
                     valid_backups[k] = v
                 else:
                     print(f"[red]Validation for {v['name']} failed[/red]\n")
             except Exception as e:
                 print(f"[red]Error during validation for {v['name']}: {e}[/red]\n")
+
+        if not valid_backups:
+            print("No valid backups found")
+            return
 
         for backup in valid_backups.values():
             log = None
@@ -475,9 +519,6 @@ class Bqckup:
             
             if backup.get('options').get('provider') == 'local':
                 destination = backup.get('options').get('destination')
-                if not destination:
-                    raise Exception("'destination' path must be configured for local provider")
-
                 backup_path = os.path.join(destination, backup_folder)
                 
                 if not os.path.exists(backup_path):
@@ -678,7 +719,7 @@ class Bqckup:
             result["notification"] = {
                  "title": f"Incremental Backup Failed for {site_config['name']}",
                  "messages": err_detail,
-                 "additional_data": { "name": "Error Message", "value": err_msg, "inline": True},
+                 "additional_data": { "name": "Error Message", "value": err_msg, "inline": False},
                  "description": (
                     "An error occurred while backup.\n"
                     "Visit the [documentation](https://docs.bqckup.com/bqckup-documentation/troubleshoots/fixing-a-corrupted-incremental-backup) to fix it"

--- a/classes/bqckup.py
+++ b/classes/bqckup.py
@@ -507,9 +507,9 @@ class Bqckup:
                         "2. There might be an issue with the database backup process.\n\n"
                         "We recommend the following steps:\n"
                         "1. Check the storage (S3) bucket {bucket_name}. If the database size is less than 1 KB or seems unusual, it likely means the backup did not complete successfully.\n"
-                        "2. Attempt to force a backup by running `bqckup --site {domain_name} --force` to ensure the backup process is functioning correctly."
+                        "2. Attempt to force a backup by running `bqckup --site {domain_name} --force` to ensure the backup process is functioning correctly.\n"
+                        "If this was a mistake, please create issue here: https://github.com/bqckup/bqckup"
                     ),
-                    "footer": "If this was a mistake, please create issue here: https://github.com/bqckup/bqckup",
                     "additional_data": {
                         "name": "File name",
                         "value": os.path.basename(compressed_file),

--- a/classes/rustic.py
+++ b/classes/rustic.py
@@ -11,7 +11,7 @@ import re
 
 from constant import RUSTIC_CONFIG_PATH
 from classes.config import Config as bqckup_config
-from helpers.utility import is_debug
+from helpers.utility import is_debug, is_verbose
 
 from rich import print  # pyright: ignore[reportMissingImports]
 
@@ -384,11 +384,17 @@ class Rustic:
                 ],  # !/tmp/dir1 # see https://github.com/rustic-rs/rustic/discussions/1194#discussioncomment-10298116
             },
             "forget": {
-                "keep-last": int(
-                    self.site_config.get("options", {}).get("retention", 7)
-                )
+                "keep-last": 1,
+                "keep-daily": 7,
+                "keep-weekly": 4,
+                "keep-monthly": 4,
             },
         }
+
+        keep = self.site_config.get("options", {}).get("keep", {})
+        for period in ("daily", "weekly", "monthly"):
+            if value := keep.get(period):
+                config["forget"][f"keep-{period}"] = value
 
         # skip saving of the snapshot if it is identical to the parent (unchanged)
         if self.version_tuple <= (0, 9, 5):
@@ -424,15 +430,15 @@ class Rustic:
             self.site_config["name"],
         ]
 
-        removed_count = 0
         try:
             print(f"Cleaning repository for '{self.site_config['name']}'...")
 
+            removed_count = 0
             output: CompletedProcess = subprocess.run(
                 command,
                 **self.__subprocess_args,  # type: ignore
             )
-
+            
             if output.stdout.strip():
                 all_outputs = self._parse_json_stream(output.stdout)
 
@@ -441,8 +447,20 @@ class Rustic:
                         continue  # skip non-list objects from stream (e.g. prune summary)
 
                     for snapshot_details in self._iter_snapshots(data):
-                        if isinstance(snapshot_details, dict) and not snapshot_details.get("keep", True):
+                        id = snapshot_details.get("id", "")[:8]
+                        reason = {", ".join(snapshot_details.get("reasons", []))}
+
+                        if snapshot_details.get("keep", True):
+                            if is_verbose():
+                                print(f"Kept snapshot {id} - reason : {reason}")
+
+                            continue
+
+                        if isinstance(snapshot_details, dict):
                             removed_count += 1
+
+                            if is_verbose():
+                                print(f"Removed snapshot {id} - reason : {reason}")
 
             if removed_count > 0:
                 print(f"Successfully removed {removed_count} snapshots.")

--- a/classes/s3.py
+++ b/classes/s3.py
@@ -73,7 +73,7 @@ class s3(object):
 
         return sum([int(f["Size"]) for f in files["Contents"]])
 
-    def get_backup_dates(self, site_name: str, sort_by_date: bool = True) -> List[str]:
+    def get_backup_dates(self, site_name: str, sort_by_date: bool = True, with_prefix: bool = True) -> List[str]:
         """
         Lists valid backup directories for a given site.
 
@@ -89,8 +89,8 @@ class s3(object):
 
         Example Output:
         [
-            "bqckups/my-site/01-January-2025/",
-            "bqckups/my-site/02-January-2025/"
+            "bqckup/my-site/01-January-2025/",
+            "bqckup/my-site/02-January-2025/"
         ]
         """
 
@@ -106,8 +106,13 @@ class s3(object):
                 continue
 
             dir_name = os.path.basename(prefix.rstrip(delimiter))
-            if BACKUP_DATE_REGEX.match(dir_name):
-                backup_prefixes.append(prefix)
+            if not BACKUP_DATE_REGEX.match(dir_name):
+                continue
+
+            if not with_prefix:
+                prefix = prefix.strip("/").split("/")[-1]
+
+            backup_prefixes.append(prefix)
 
         if sort_by_date:
             backup_prefixes.sort(
@@ -162,8 +167,6 @@ class s3(object):
             if is_verbose():
                 for k in objects:
                     print(f"Removed {k}")
-
-            print(f"Deleted {len(objects)} objects")
 
         except Exception as e:
             raise Exception(f"failed to delete objects in bucket: {e}") from e

--- a/helpers/backup.py
+++ b/helpers/backup.py
@@ -1,0 +1,133 @@
+from datetime import datetime
+from typing import Dict, List, Set, Tuple
+
+
+def get_week_of_year(date: datetime) -> Tuple[int, int]:
+    """
+    Calculates the ISO week key for a given date.
+
+    Args:
+        date: A datetime object.
+
+    Returns:
+        A tuple containing the year and week number.
+    """
+    iso_calendar = date.isocalendar()
+    return (iso_calendar[0], iso_calendar[1])
+
+
+def get_month_of_year(date: datetime) -> Tuple[int, int]:
+    """
+    Calculates the month key for a given date.
+
+    Args:
+        date: A datetime object.
+
+    Returns:
+        A tuple containing the year and month.
+    """
+    return (date.year, date.month)
+
+
+def mark_backups(dates: List[datetime]) -> Dict[datetime, Set[str]]:
+    """
+    Assigns retention markers (daily, weekly, monthly) to each backup date.
+
+    Args:
+        dates: A list of backup dates, sorted ascendingly (oldest first).
+
+    Returns:
+        A dictionary mapping each date to a set of markers.
+    """
+    if not dates:
+        return {}
+
+    result = {}
+    seen_weeks = set()
+    seen_months = set()
+
+    for i, date in enumerate(dates):
+        markers = set()
+        markers.add("daily")
+
+        week_key = get_week_of_year(date)
+        month_key = get_month_of_year(date)
+
+        if week_key not in seen_weeks:
+            markers.add("weekly")
+            seen_weeks.add(week_key)
+
+        if month_key not in seen_months:
+            markers.add("monthly")
+            seen_months.add(month_key)
+
+        # first backup always gets weekly and monthly markers
+        if i == 0:
+            markers.add("weekly")
+            markers.add("monthly")
+
+        result[date] = markers
+
+    return result
+
+
+def get_backup_to_keep(
+    markers_map: Dict[datetime, Set[str]], policy: Dict[str, int]
+) -> Set[datetime]:
+    """
+    Applies a retention policy to determine which backups to keep.
+
+    Args:
+        markers_map: A dictionary mapping dates to a set of markers.
+        policy: A dictionary with 'daily', 'weekly', 'monthly' keys and quota values.
+
+    Returns:
+        A set of dates that should be kept.
+    """
+    sorted_dates = sorted(markers_map.keys(), reverse=True)
+
+    kept_monthly = []
+    kept_weekly = []
+    kept_daily = []
+
+    dates_to_keep = set()
+
+    for date in sorted_dates:
+        markers = markers_map.get(date, set())
+        should_keep = False
+
+        if "monthly" in markers and len(kept_monthly) < policy.get("monthly", 0):
+            kept_monthly.append(date)
+            should_keep = True
+
+        if "weekly" in markers and len(kept_weekly) < policy.get("weekly", 0):
+            kept_weekly.append(date)
+            should_keep = True
+
+        if "daily" in markers and len(kept_daily) < policy.get("daily", 0):
+            kept_daily.append(date)
+            should_keep = True
+
+        if should_keep:
+            dates_to_keep.add(date)
+
+    return dates_to_keep
+
+
+def get_backups_to_keep(dates: List[datetime], policy: Dict[str, int]) -> Set[datetime]:
+    """
+    Applies a retention policy to a list of dates.
+
+    Args:
+        dates: A list of backup dates.
+        policy: A dictionary with 'daily', 'weekly', 'monthly' keys and quota values.
+
+    Returns:
+        A set of dates that should be kept according to the policy.
+    """
+    if not dates:
+        return set()
+
+    sorted_dates = sorted(dates)
+    markers = mark_backups(sorted_dates)
+    return get_backup_to_keep(markers, policy)

--- a/sites/domain.yml.example
+++ b/sites/domain.yml.example
@@ -28,6 +28,10 @@ bqckup:
     storage: dummy
     interval: daily #can be daily, weekly, monthly 
     retention: '7'
+    keep:
+      daily: 7
+      weekly: 2
+      monthly: 1
     follow_symlink: no
     save_locally: no
     save_locally_path: /etc/bqckup/tmp

--- a/sites/domain.yml.example
+++ b/sites/domain.yml.example
@@ -30,8 +30,8 @@ bqckup:
     retention: '7'
     keep:
       daily: 7
-      weekly: 2
-      monthly: 1
+      weekly: 4
+      monthly: 4
     follow_symlink: no
     save_locally: no
     save_locally_path: /etc/bqckup/tmp

--- a/tests/unit/test_helpers/test_backup_retention.py
+++ b/tests/unit/test_helpers/test_backup_retention.py
@@ -1,0 +1,85 @@
+import pytest
+from datetime import datetime
+from helpers.backup import get_backups_to_keep
+
+TEST_CASES = [
+    (
+        "no_backups",
+        [],
+        {"daily": 7, "weekly": 4, "monthly": 12},
+        set(),
+    ),
+    (
+        "not_enough_backups",
+        [datetime(2025, 1, 1)],
+        {"daily": 7, "weekly": 4, "monthly": 12},
+        {datetime(2025, 1, 1)},
+    ),
+    (
+        "only_daily",
+        [datetime(2025, 1, d) for d in range(1, 6)],
+        {"daily": 2, "weekly": 0, "monthly": 0},
+        {datetime(2025, 1, 5), datetime(2025, 1, 4)},
+    ),
+    (
+        "weekly_and_daily",
+        [datetime(2025, 1, d) for d in range(1, 15)],  # Jan 1 to 14
+        {"daily": 2, "weekly": 2, "monthly": 1},
+        {
+            datetime(2025, 1, 14),  # daily
+            datetime(2025, 1, 13),  # daily, weekly
+            datetime(2025, 1, 6),  # weekly
+            datetime(2025, 1, 1),  # monthly (and weekly)
+        },
+    ),
+    (
+        "multi_month",
+        [datetime(2024, 12, d) for d in range(25, 32)]
+        + [datetime(2025, 1, d) for d in range(1, 11)],
+        {"daily": 3, "weekly": 2, "monthly": 2},
+        {
+            datetime(2025, 1, 10),  # daily
+            datetime(2025, 1, 9),  # daily
+            datetime(2025, 1, 8),  # daily
+            datetime(2025, 1, 6),  # weekly
+            datetime(2025, 1, 1),  # monthly
+            datetime(2024, 12, 30),  # weekly
+            datetime(2024, 12, 25),  # monthly (and weekly)
+        },
+    ),
+    (
+        "zero_policy",
+        [datetime(2025, 1, d) for d in range(1, 11)],
+        {"daily": 0, "weekly": 0, "monthly": 0},
+        set(),
+    ),
+    (
+        "more_retention_than_backups",
+        [datetime(2025, 1, d) for d in range(1, 5)],
+        {"daily": 10, "weekly": 10, "monthly": 10},
+        {datetime(2025, 1, d) for d in range(1, 5)},
+    ),
+    (
+        "first_backup_is_kept",
+        [datetime(2025, 1, 1), datetime(2025, 1, 2)],
+        {"daily": 1, "weekly": 1, "monthly": 1},
+        {datetime(2025, 1, 2), datetime(2025, 1, 1)},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_id, dates, policy, expected", TEST_CASES, ids=[t[0] for t in TEST_CASES]
+)
+def test_get_backups_to_keep(test_id, dates, policy, expected):
+    """
+    Tests the get_backups_to_keep function with various scenarios.
+
+    Args:
+        test_id: An identifier for the test case.
+        dates: A list of datetime objects representing backup dates.
+        policy: A dictionary defining the retention policy.
+        expected: A set of datetime objects that should be kept.
+    """
+    result = get_backups_to_keep(dates, policy)
+    assert result == expected


### PR DESCRIPTION
## What’s New

- added version to discord footer field
- new retention config

---

## New Configuration

```diff
bqckup:
  name: domain.my.id
  enabled: yes
  options:
    interval: daily
    retention: '7'
+   keep:
+     daily: 7
+     weekly: 2
+     monthly: 1
```

---

## Behavior Changes

### Previous Behavior

Backups were retained based solely on the total number specified in `retention`.

### New Behavior

Backups are now retained according to explicit rules defined per period:

* `daily`
* `weekly`
* `monthly`

This provides finer control over backup retention policies.

---

## Backward Compatibility

* If `keep` is **not configured**, the existing `retention` value will be **automatically mapped to `keep.daily`**.
* If `keep` is **not configured**, incremental snapshot retention will fall back to the following defaults:

  * `daily`: 7
  * `weekly`: 4
  * `monthly`: 4

This default is chosen because **differences between incremental snapshots consume relatively few resources**, making it safe to retain more historical data.

---

## Notes

* Use the `--verbose` flag **after the binary name** to see detailed information about:

  * which backups are deleted
  * deletion reason for incremental backups
  * additional cleanup details
* The code does **not** use markers or metadata to explicitly tag which backups should be kept. Retention is determined purely by configuration and snapshot evaluation logic.




close #127 