### PR TITLE
Fix Silent Database Backup Failure

### DIFF
--- a/classes/bqckup.py
+++ b/classes/bqckup.py
@@ -761,7 +761,7 @@ class Bqckup:
                     site_name=site_config["name"],
                     db_label=db_label,
                     backup_path=backup_path,
-                    current_log=current_log,
+                    time_consumed=result.get("time_consumed", 0),
                     should_save_locally=should_save_locally,
                     save_locally_path=save_locally_path,
                 )
@@ -825,7 +825,7 @@ class Bqckup:
         site_name: str,
         db_label: str,
         backup_path: Path,
-        current_log: Log,
+        time_consumed: float,
         should_save_locally: bool = False,
         save_locally_path: Path | None = None,
     ) -> None:
@@ -839,7 +839,7 @@ class Bqckup:
         try:
             if last_log:
                 previous_size = format_size(last_log.file_size)
-                time_consume = format_timespan(current_log.time_consume)
+                formatted_time_consume = format_timespan(time_consumed)
                 current_size = format_size(backup_path.stat().st_size)
 
                 print("=========================================")
@@ -847,7 +847,7 @@ class Bqckup:
                 print(f"Database\t: {db_label}")
                 print(f"Previous Size\t: {previous_size}")
                 print(f"Current Size\t: {current_size}")
-                print(f"Time Consumed\t: {time_consume}")
+                print(f"Time Consumed\t: {formatted_time_consume}")
                 print("=========================================")
 
                 if previous_size == current_size:

--- a/classes/database.py
+++ b/classes/database.py
@@ -1,6 +1,8 @@
-import logging, os
+import gzip
+import logging
 import subprocess
 from typing import Any, List, Dict
+
 
 # Database Exceptions
 class DatabaseException(Exception):
@@ -10,13 +12,15 @@ class DatabaseException(Exception):
 """
 should be compatible with to other database type
 """
+
+
 class Database:
     # mysqli is temporary
     SUPPORTED_DATABASE = ("mysql", "postgresql", "sqlite")
-    
-    def __init__(self, type = "mysql"):
+
+    def __init__(self, type="mysql"):
         self.type = type.lower()
-        
+
     def export(
         self,
         output: str,
@@ -27,32 +31,44 @@ class Database:
         db_port: int = 3306,
     ) -> None:
         command = [
-                "mysqldump",
-                f"--user={db_user}",
-                f"--password={db_password}",
-                f"--host={db_host}",
-                f"--port={db_port}",
-                db_name,
-                "--no-tablespaces ",
-                "--skip-dump-date",
-                "|",
-                "gzip",
-                ">",
-                output
-            ]        
-        with open(os.devnull, 'w') as devnull:
-                subprocess.run(" ".join(command), shell=True, stdout=devnull, stderr=devnull)
-    
-    def test_connection(self, credentials: dict) -> bool:
+            "mysqldump",
+            f"--user={db_user}",
+            f"--password={db_password}",
+            f"--host={db_host}",
+            f"--port={db_port}",
+            "--no-tablespaces",
+            "--skip-dump-date",
+            db_name,
+        ]
+
+        with gzip.open(output, "wb") as f:
+            process = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            for chunk in iter(lambda: process.stdout.read(4096), b""):
+                f.write(chunk)
+
+            process.wait()
+
+            if process.returncode != 0:
+                error = process.stderr.read().decode()
+                raise Exception(error)
+
+    def test_connection(self, credentials: dict) -> None:
         import mysql.connector
+
         try:
             c = mysql.connector.connect(
-                user=credentials['user'],
-                host=credentials['host'],
-                port=credentials['port'],
-                password=credentials['password'],
-                database=credentials['name'])
-        
+                user=credentials["user"],
+                host=credentials["host"],
+                port=credentials["port"],
+                password=credentials["password"],
+                database=credentials["name"],
+            )
+
         except mysql.connector.Error as e:
             logging.error(e)
             raise DatabaseException("Failed to connect database, see log for details")
@@ -71,7 +87,7 @@ class Database:
             databases.append(database)
 
         for database in databases:
-            # if the key is missing, default to backing up the database
+            # if enabled key is missing, default to true
             if not ("enabled" in database or "enable" in database):
                 result.append(database)
                 continue

--- a/sites/domain.yml.example
+++ b/sites/domain.yml.example
@@ -28,6 +28,10 @@ bqckup:
     storage: dummy
     interval: daily #can be daily, weekly, monthly 
     retention: '7'
+    keep:
+      daily: 7
+      weekly: 4
+      monthly: 4
     follow_symlink: no
     save_locally: no
     save_locally_path: /etc/bqckup/tmp

--- a/sites/domain.yml.example
+++ b/sites/domain.yml.example
@@ -28,10 +28,6 @@ bqckup:
     storage: dummy
     interval: daily #can be daily, weekly, monthly 
     retention: '7'
-    keep:
-      daily: 7
-      weekly: 4
-      monthly: 4
     follow_symlink: no
     save_locally: no
     save_locally_path: /etc/bqckup/tmp

--- a/tests/unit/test_classes/test_database.py
+++ b/tests/unit/test_classes/test_database.py
@@ -1,4 +1,5 @@
 import pytest
+import subprocess
 from unittest.mock import Mock, patch, MagicMock
 from classes.database import Database, DatabaseException
 
@@ -21,22 +22,40 @@ class TestDatabase:
         assert "postgresql" in Database.SUPPORTED_DATABASE
         assert "sqlite" in Database.SUPPORTED_DATABASE
     
-    @patch('subprocess.run')
-    @patch('builtins.open')
-    def test_export_success(self, mock_open, mock_subprocess):
+    @patch('gzip.open')
+    @patch('subprocess.Popen')
+    def test_export_success(self, mock_popen, mock_gzip_open):
         db = Database("mysql")
-        mock_devnull = MagicMock()
-        mock_open.return_value.__enter__.return_value = mock_devnull
+        mock_file = MagicMock()
+        mock_gzip_open.return_value.__enter__.return_value = mock_file
+
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_process.stdout.read.side_effect = [b'test data', b'']
+        mock_process.stderr.read.return_value = b''
+        mock_popen.return_value = mock_process
         
         db.export("/tmp/backup.sql.gz", "testuser", "testpass", "testdb", "localhost")
         
-        expected_command = "mysqldump --user=testuser --password=testpass --host=localhost --port=3306 testdb --no-tablespaces  --skip-dump-date | gzip > /tmp/backup.sql.gz"
-        mock_subprocess.assert_called_once_with(
+        expected_command = [
+            "mysqldump",
+            "--user=testuser",
+            "--password=testpass",
+            "--host=localhost",
+            "--port=3306",
+            "--no-tablespaces",
+            "--skip-dump-date",
+            "testdb",
+        ]
+
+        mock_popen.assert_called_once_with(
             expected_command,
-            shell=True,
-            stdout=mock_devnull,
-            stderr=mock_devnull
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
+        mock_process.stdout.read.assert_called()
+        mock_file.write.assert_called_once_with(b'test data')
+        mock_process.wait.assert_called_once()
     
     @patch('mysql.connector.connect')
     def test_connection_success(self, mock_connect):
@@ -52,7 +71,7 @@ class TestDatabase:
             'name': 'testdb'
         }
         
-        result = db.test_connection(credentials)
+        db.test_connection(credentials)
         
         mock_connect.assert_called_once_with(
             user='testuser',


### PR DESCRIPTION
## Problem

When `mysqldump` fails, Python still considers the backup process successful.
This happens because the command uses a shell pipeline (`| gzip`), and the shell only returns the exit code of the **last command** (`gzip`). As a result, errors from `mysqldump` are silently ignored as long as `gzip` succeeds.

---

## Solution

Compression is now handled directly by the Python standard library instead of relying on shell piping.
By removing the shell pipeline, Python can correctly detect failures from `mysqldump` and raise an error when the dump process fails.

---

## Previous Implementation

```text
mysqldump \
  --user=... \
  --password=... \
  --host=... \
  db_name \
  --no-tablespaces \
  --skip-dump-date |
gzip > output
```

---

## Result

* `mysqldump` errors are properly propagated to Python
* Backup failures are no longer reported as successful
* Improved reliability and error handling for the backup process

fix #128 