### PR TITLE
Add multiple dbms

### DIFF
--- a/classes/bqckup.py
+++ b/classes/bqckup.py
@@ -1016,7 +1016,7 @@ class Bqckup:
 
         try:
             with ProgressSpinner(f"Exporting database {db_label}"):
-                Database().export(
+                Database(type=database.get("type", "mysql")).export(
                     str(backup_path),
                     db_user=database["user"],
                     db_password=database["password"],

--- a/classes/database.py
+++ b/classes/database.py
@@ -9,24 +9,64 @@ from rich import print
 from typing import Any, List, Dict, Optional
 
 
-# Database Exceptions
 class DatabaseException(Exception):
     pass
 
 
 DATABASE_LOG = LOG_DIR / "database.log"
 
-"""
-should be compatible with to other database type
-"""
-
 
 class Database:
-    # mysqli is temporary
     SUPPORTED_DATABASE = ("mysql", "postgresql", "sqlite")
 
     def __init__(self, type="mysql"):
         self.type = type.lower()
+
+    def _get_mysql_command(
+        self,
+        db_user: str,
+        db_password: str,
+        db_name: str,
+        db_host: str,
+        db_port: int,
+    ) -> list:
+        return [
+            "mysqldump",
+            f"--user={db_user}",
+            f"--password={db_password}",
+            f"--host={db_host}",
+            f"--port={db_port}",
+            "--no-tablespaces",
+            "--skip-dump-date",
+            db_name,
+        ]
+
+    def _get_postgresql_command(
+        self,
+        db_user: str,
+        db_password: str,
+        db_name: str,
+        db_host: str,
+        db_port: int,
+    ) -> tuple:
+        env = os.environ.copy()
+        env["PGPASSWORD"] = db_password
+
+        command = [
+            "pg_dump",
+            "-U",
+            db_user,
+            "-h",
+            db_host,
+            "-p",
+            str(db_port),
+            db_name,
+        ]
+
+        return command, env
+
+    def _get_sqlite_command(self, db_name: str) -> list:
+        return ["sqlite3", db_name, ".dump"]
 
     def export(
         self,
@@ -43,17 +83,26 @@ class Database:
         if not log_file.parent.exists():
             log_file.parent.mkdir(parents=True, exist_ok=True)
 
-        label = f"{db_user}@{db_host}:{db_port}/{db_name}"
-        command = [
-            "mysqldump",
-            f"--user={db_user}",
-            f"--password={db_password}",
-            f"--host={db_host}",
-            f"--port={db_port}",
-            "--no-tablespaces",
-            "--skip-dump-date",
-            db_name,
-        ]
+        label = (
+            f"{db_user}@{db_host}:{db_port}/{db_name}"
+            if self.type != "sqlite"
+            else f"sqlite:{db_name}"
+        )
+
+        if self.type == "mysql":
+            command = self._get_mysql_command(
+                db_user, db_password, db_name, db_host, db_port
+            )
+            env = None
+        elif self.type == "postgresql":
+            command, env = self._get_postgresql_command(
+                db_user, db_password, db_name, db_host, db_port
+            )
+        elif self.type == "sqlite":
+            command = self._get_sqlite_command(db_name)
+            env = None
+        else:
+            raise DatabaseException(f"Unsupported database type: {self.type}")
 
         with open(log_file, "ab") as log:
             now = datetime.now()
@@ -64,6 +113,7 @@ class Database:
                 command,
                 stdout=subprocess.PIPE,
                 stderr=log,
+                env=env if env else os.environ,
             )
 
             try:
@@ -95,6 +145,16 @@ class Database:
                 raise
 
     def test_connection(self, credentials: dict) -> None:
+        if self.type == "mysql":
+            self._test_mysql_connection(credentials)
+        elif self.type == "postgresql":
+            self._test_postgresql_connection(credentials)
+        elif self.type == "sqlite":
+            self._test_sqlite_connection(credentials)
+        else:
+            raise DatabaseException(f"Unsupported database type: {self.type}")
+
+    def _test_mysql_connection(self, credentials: dict) -> None:
         import mysql.connector
 
         try:
@@ -112,6 +172,44 @@ class Database:
         else:
             c.close()
         return
+
+    def _test_postgresql_connection(self, credentials: dict) -> None:
+        import psycopg2
+
+        try:
+            c = psycopg2.connect(
+                user=credentials["user"],
+                host=credentials["host"],
+                port=credentials["port"],
+                password=credentials["password"],
+                dbname=credentials["name"],
+            )
+
+        except psycopg2.Error as e:
+            logging.error(e)
+            raise DatabaseException("Failed to connect database, see log for details")
+        else:
+            c.close()
+        return
+
+    def _test_sqlite_connection(self, credentials: dict) -> None:
+        db_path = credentials.get("name")
+        if not db_path:
+            raise DatabaseException("SQLite database path (name) is required")
+
+        if not os.path.exists(db_path):
+            raise DatabaseException(f"SQLite database file not found: {db_path}")
+
+        import sqlite3
+
+        try:
+            c = sqlite3.connect(db_path)
+            c.close()
+        except sqlite3.Error as e:
+            logging.error(e)
+            raise DatabaseException(
+                "Failed to connect to SQLite database, see log for details"
+            )
 
     @staticmethod
     def get_all(site_config: dict) -> List[Dict[str, Any]]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Flask-WTF
 gunicorn
 hurry.filesize
 mysql-connector-python==8.0.20
+psycopg2-binary
 peewee
 pyinstaller
 python-decouple

--- a/tests/fixtures/mixed_database_site.yml
+++ b/tests/fixtures/mixed_database_site.yml
@@ -1,0 +1,39 @@
+bqckup:
+  name: mixed_db_test
+  enabled: yes
+  path:
+    - /var/www/html/mixed_site
+  databases:
+    - enabled: yes
+      type: mysql
+      host: localhost
+      port: 3306
+      user: mysql_user
+      password: mysql_pass
+      name: mysql_database
+    - enabled: yes
+      type: postgresql
+      host: localhost
+      port: 5432
+      user: pg_user
+      password: pg_pass
+      name: pg_database
+    - enabled: yes
+      type: sqlite
+      name: /var/data/app.sqlite
+    - enabled: no
+      type: mysql
+      host: localhost
+      port: 3306
+      user: disabled_user
+      password: disabled_pass
+      name: disabled_database
+  options:
+    storage: test_storage
+    interval: daily
+    retention: '14'
+    follow_symlink: no
+    save_locally: yes
+    save_locally_path: /tmp/backups
+    notification_email: admin@example.com
+    provider: s3

--- a/tests/fixtures/postgresql_site.yml
+++ b/tests/fixtures/postgresql_site.yml
@@ -1,0 +1,21 @@
+bqckup:
+  name: postgres_test
+  enabled: yes
+  path:
+    - /var/www/html/postgres_site
+  database:
+    enabled: yes
+    type: postgresql
+    host: localhost
+    port: 5432
+    user: pg_user
+    password: pg_pass
+    name: pg_database
+  options:
+    storage: test_storage
+    interval: daily
+    retention: '7'
+    follow_symlink: no
+    save_locally: no
+    notification_email: admin@example.com
+    provider: s3

--- a/tests/fixtures/sqlite_site.yml
+++ b/tests/fixtures/sqlite_site.yml
@@ -1,0 +1,17 @@
+bqckup:
+  name: sqlite_test
+  enabled: yes
+  path:
+    - /var/www/html/sqlite_site
+  database:
+    enabled: yes
+    type: sqlite
+    name: /var/data/app.sqlite
+  options:
+    storage: test_storage
+    interval: daily
+    retention: '7'
+    follow_symlink: no
+    save_locally: no
+    notification_email: admin@example.com
+    provider: s3

--- a/tests/unit/test_classes/test_database.py
+++ b/tests/unit/test_classes/test_database.py
@@ -3,28 +3,33 @@ import subprocess
 from unittest.mock import Mock, patch, MagicMock
 from classes.database import Database, DatabaseException
 
+
 class TestDatabase:
-    
     def test_init_mysql(self):
         db = Database("mysql")
         assert db.type == "mysql"
-    
+
     def test_init_postgresql(self):
         db = Database("postgresql")
         assert db.type == "postgresql"
-    
+
+    def test_init_sqlite(self):
+        db = Database("sqlite")
+        assert db.type == "sqlite"
+
     def test_init_case_insensitive(self):
         db = Database("MYSQL")
         assert db.type == "mysql"
-    
+
     def test_supported_databases(self):
         assert "mysql" in Database.SUPPORTED_DATABASE
         assert "postgresql" in Database.SUPPORTED_DATABASE
         assert "sqlite" in Database.SUPPORTED_DATABASE
-    
-    @patch('gzip.open')
-    @patch('subprocess.Popen')
-    def test_export_success(self, mock_popen, mock_gzip_open):
+
+    # MySQL Tests
+    @patch("gzip.open")
+    @patch("subprocess.Popen")
+    def test_export_mysql_success(self, mock_popen, mock_gzip_open):
         db = Database("mysql")
 
         mock_file = MagicMock()
@@ -32,11 +37,18 @@ class TestDatabase:
 
         mock_process = MagicMock()
         mock_process.returncode = 0
-        mock_process.stdout.read.side_effect = [b'test data', b'']
+        mock_process.stdout.read.side_effect = [b"test data", b""]
         mock_popen.return_value = mock_process
 
-        db.export("/tmp/backup.sql.gz", "testuser", "testpass", "testdb", "localhost", log_dir="/tmp/bqckup")
-        
+        db.export(
+            "/tmp/backup.sql.gz",
+            "testuser",
+            "testpass",
+            "testdb",
+            "localhost",
+            log_dir="/tmp/bqckup",
+        )
+
         expected_command = [
             "mysqldump",
             "--user=testuser",
@@ -50,51 +62,234 @@ class TestDatabase:
 
         args, kwargs = mock_popen.call_args
         assert args[0] == expected_command
-        assert kwargs['stdout'] == subprocess.PIPE
-        assert 'stderr' in kwargs
+        assert kwargs["stdout"] == subprocess.PIPE
+        assert "stderr" in kwargs
 
         mock_process.stdout.read.assert_called()
-        mock_file.write.assert_called_once_with(b'test data')
+        mock_file.write.assert_called_once_with(b"test data")
         mock_process.wait.assert_called_once()
-    
-    @patch('mysql.connector.connect')
-    def test_connection_success(self, mock_connect):
+
+    @patch("mysql.connector.connect")
+    def test_mysql_connection_success(self, mock_connect):
         mock_connection = Mock()
         mock_connect.return_value = mock_connection
-        
+
         db = Database("mysql")
         credentials = {
-            'user': 'testuser',
-            'host': 'localhost',
-            'password': 'testpass',
-            'port': 3306,
-            'name': 'testdb'
+            "user": "testuser",
+            "host": "localhost",
+            "password": "testpass",
+            "port": 3306,
+            "name": "testdb",
         }
-        
+
         db.test_connection(credentials)
-        
+
         mock_connect.assert_called_once_with(
-            user='testuser',
-            host='localhost',
+            user="testuser",
+            host="localhost",
             port=3306,
-            password='testpass',
-            database='testdb'
+            password="testpass",
+            database="testdb",
         )
         mock_connection.close.assert_called_once()
-    
-    @patch('mysql.connector.connect')
-    def test_connection_failure(self, mock_connect):
+
+    @patch("mysql.connector.connect")
+    def test_mysql_connection_failure(self, mock_connect):
         import mysql.connector
+
         mock_connect.side_effect = mysql.connector.Error("Connection failed")
-        
+
         db = Database("mysql")
         credentials = {
-            'user': 'testuser',
-            'host': 'localhost',
-            'port': 3306,
-            'password': 'testpass',
-            'name': 'testdb'
+            "user": "testuser",
+            "host": "localhost",
+            "port": 3306,
+            "password": "testpass",
+            "name": "testdb",
         }
-        
+
         with pytest.raises(DatabaseException, match="Failed to connect database"):
             db.test_connection(credentials)
+
+    # PostgreSQL Tests
+    @patch("gzip.open")
+    @patch("subprocess.Popen")
+    def test_export_postgresql_success(self, mock_popen, mock_gzip_open):
+        db = Database("postgresql")
+
+        mock_file = MagicMock()
+        mock_gzip_open.return_value.__enter__.return_value = mock_file
+
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_process.stdout.read.side_effect = [b"test data", b""]
+        mock_popen.return_value = mock_process
+
+        db.export(
+            "/tmp/backup.sql.gz",
+            "testuser",
+            "testpass",
+            "testdb",
+            "localhost",
+            5432,
+            log_dir="/tmp/bqckup",
+        )
+
+        expected_command = [
+            "pg_dump",
+            "-U",
+            "testuser",
+            "-h",
+            "localhost",
+            "-p",
+            "5432",
+            "testdb",
+        ]
+
+        args, kwargs = mock_popen.call_args
+        assert args[0] == expected_command
+        assert kwargs["stdout"] == subprocess.PIPE
+        assert "stderr" in kwargs
+        assert kwargs["env"]["PGPASSWORD"] == "testpass"
+
+        mock_process.stdout.read.assert_called()
+        mock_file.write.assert_called_once_with(b"test data")
+        mock_process.wait.assert_called_once()
+
+    @patch("gzip.open")
+    @patch("subprocess.Popen")
+    def test_export_postgresql_default_port(self, mock_popen, mock_gzip_open):
+        db = Database("postgresql")
+
+        mock_file = MagicMock()
+        mock_gzip_open.return_value.__enter__.return_value = mock_file
+
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_process.stdout.read.side_effect = [b"test data", b""]
+        mock_popen.return_value = mock_process
+
+        db.export("/tmp/backup.sql.gz", "testuser", "testpass", "testdb", "localhost")
+
+        args, _ = mock_popen.call_args
+        command = args[0]
+        assert command[0] == "pg_dump"
+        assert "-p" in command
+        port_index = command.index("-p")
+        assert command[port_index + 1] == "3306"
+
+    @patch("psycopg2.connect")
+    def test_postgresql_connection_success(self, mock_connect):
+        mock_connection = Mock()
+        mock_connect.return_value = mock_connection
+
+        db = Database("postgresql")
+        credentials = {
+            "user": "pguser",
+            "host": "localhost",
+            "password": "pgpass",
+            "port": 5432,
+            "name": "pgdb",
+        }
+
+        db.test_connection(credentials)
+
+        mock_connect.assert_called_once_with(
+            user="pguser", host="localhost", port=5432, password="pgpass", dbname="pgdb"
+        )
+        mock_connection.close.assert_called_once()
+
+    @patch("psycopg2.connect")
+    def test_postgresql_connection_failure(self, mock_connect):
+        import psycopg2
+
+        mock_connect.side_effect = psycopg2.Error("Connection failed")
+
+        db = Database("postgresql")
+        credentials = {
+            "user": "pguser",
+            "host": "localhost",
+            "port": 5432,
+            "password": "pgpass",
+            "name": "pgdb",
+        }
+
+        with pytest.raises(DatabaseException, match="Failed to connect database"):
+            db.test_connection(credentials)
+
+    # SQLite Tests
+    @patch("gzip.open")
+    @patch("subprocess.Popen")
+    def test_export_sqlite_success(self, mock_popen, mock_gzip_open):
+        db = Database("sqlite")
+
+        mock_file = MagicMock()
+        mock_gzip_open.return_value.__enter__.return_value = mock_file
+
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_process.stdout.read.side_effect = [b"sqlite dump", b""]
+        mock_popen.return_value = mock_process
+
+        db.export(
+            "/tmp/backup.sql.gz", "", "", "/path/to/db.sqlite", log_dir="/tmp/bqckup"
+        )
+
+        expected_command = ["sqlite3", "/path/to/db.sqlite", ".dump"]
+
+        args, kwargs = mock_popen.call_args
+        assert args[0] == expected_command
+        assert kwargs["stdout"] == subprocess.PIPE
+        assert "stderr" in kwargs
+
+        mock_process.stdout.read.assert_called()
+        mock_file.write.assert_called_once_with(b"sqlite dump")
+        mock_process.wait.assert_called_once()
+
+    @patch("sqlite3.connect")
+    @patch("os.path.exists")
+    def test_sqlite_connection_success(self, mock_exists, mock_connect):
+        mock_exists.return_value = True
+        mock_connection = Mock()
+        mock_connect.return_value = mock_connection
+
+        db = Database("sqlite")
+        credentials = {"name": "/path/to/database.sqlite"}
+
+        db.test_connection(credentials)
+
+        mock_exists.assert_called_once_with("/path/to/database.sqlite")
+        mock_connect.assert_called_once_with("/path/to/database.sqlite")
+        mock_connection.close.assert_called_once()
+
+    @patch("os.path.exists")
+    def test_sqlite_connection_file_not_found(self, mock_exists):
+        mock_exists.return_value = False
+
+        db = Database("sqlite")
+        credentials = {"name": "/path/to/nonexistent.sqlite"}
+
+        with pytest.raises(DatabaseException, match="SQLite database file not found"):
+            db.test_connection(credentials)
+
+    def test_sqlite_connection_missing_path(self):
+        db = Database("sqlite")
+        credentials = {}
+
+        with pytest.raises(DatabaseException, match="SQLite database path"):
+            db.test_connection(credentials)
+
+    # Unsupported database type tests
+    def test_export_unsupported_type(self):
+        db = Database("unsupported")
+
+        with pytest.raises(DatabaseException, match="Unsupported database type"):
+            db.export("/tmp/backup.sql.gz", "user", "pass", "db")
+
+    def test_connection_unsupported_type(self):
+        db = Database("unsupported")
+        db.type = "unsupported"
+
+        with pytest.raises(DatabaseException, match="Unsupported database type"):
+            db.test_connection({})


### PR DESCRIPTION
This pull request adds support for backing up and testing connections for PostgreSQL and SQLite databases, in addition to the existing MySQL support. The changes refactor the `Database` class to handle multiple database types, update the backup logic, and significantly expand the test suite to ensure correct behavior for all supported databases.

**Multi-database support and refactoring:**

* Refactored the `Database` class in `classes/database.py` to support MySQL, PostgreSQL, and SQLite by introducing type-specific command generators and connection testers. Now, the `export` and `test_connection` methods handle all three database types, raising an exception for unsupported types. [[1]](diffhunk://#diff-6f8e6bcc17afa449fb026e1b9968a3df13eba033834600f6ae7b788993e8e9dfL12-R70) [[2]](diffhunk://#diff-6f8e6bcc17afa449fb026e1b9968a3df13eba033834600f6ae7b788993e8e9dfL46-R105) [[3]](diffhunk://#diff-6f8e6bcc17afa449fb026e1b9968a3df13eba033834600f6ae7b788993e8e9dfR116) [[4]](diffhunk://#diff-6f8e6bcc17afa449fb026e1b9968a3df13eba033834600f6ae7b788993e8e9dfR148-R157) [[5]](diffhunk://#diff-6f8e6bcc17afa449fb026e1b9968a3df13eba033834600f6ae7b788993e8e9dfR176-R213)
* Updated the backup process in `classes/bqckup.py` to instantiate the `Database` class with the correct type from the configuration, enabling proper handling of different database types during backup.

**Testing improvements:**

* Expanded the unit tests in `tests/unit/test_classes/test_database.py` to cover PostgreSQL and SQLite export and connection scenarios, including success and failure cases, as well as error handling for unsupported types. [[1]](diffhunk://#diff-58ea9fb828b64bc3b6e70330e0a3f13b648dffdd6972e3b9d72430a744be798fL6-R7) [[2]](diffhunk://#diff-58ea9fb828b64bc3b6e70330e0a3f13b648dffdd6972e3b9d72430a744be798fR16-R19) [[3]](diffhunk://#diff-58ea9fb828b64bc3b6e70330e0a3f13b648dffdd6972e3b9d72430a744be798fL25-R50) [[4]](diffhunk://#diff-58ea9fb828b64bc3b6e70330e0a3f13b648dffdd6972e3b9d72430a744be798fL53-R295)
* Added fixture files for PostgreSQL, SQLite, and mixed database site configurations to facilitate testing of various backup scenarios. (`tests/fixtures/postgresql_site.yml`, `tests/fixtures/sqlite_site.yml`, `tests/fixtures/mixed_database_site.yml`) [[1]](diffhunk://#diff-9248af25e481d9b8312c8236edd2901913d7d0f8cc17da8484ce30d6489dbbccR1-R21) [[2]](diffhunk://#diff-00c42d2f6007be7fd143730424b3aadd358531782a48f0ce3dec5c96b5f2ac67R1-R17) [[3]](diffhunk://#diff-7b8d7b3c90e725501f81a6df6a694840ea300340d293f24f75beb7133d098e96R1-R39)