### PR TITLE
Email Notification

### DIFF
--- a/bqckup.cnf.example
+++ b/bqckup.cnf.example
@@ -17,29 +17,39 @@ root_folder_name=bqckup
 anonymous_statistic=1
 
 [notification]
-; Enable or disable notification
+; Master switch for ALL notifications (1 = on, 0 = off)
 enabled=0
 
-; reports will be sent at the end of every month, make sure notification are enabled
+; Send a monthly report at the end of every month (requires enabled=1)
 monthly_report_enabled=0
 
-; Notification channels, comma separated. Supported: discord, email
+; Which channels to send to. Comma separated. Supported: discord, email
+;   channel=discord        -> only Discord
+;   channel=email          -> only Email
+;   channel=discord,email  -> both
 channel=discord
 
-; Webhook URL
+; --- Discord channel ---
+; Webhook URL (required when 'discord' is in channel)
 discord_webhook_url=
 
-; Recipient address for the email channel (comma separated for multiple)
+; --- Email channel ---
+; Recipient address(es), comma separated (required when 'email' is in channel)
+; The SMTP sender account is configured in the [email] section below
 email_to=
 
 [email]
-; SMTP sender settings, used when the `email` notification channel is enabled
+; SMTP sender settings, used when the 'email' channel is enabled above.
+; Display name shown as the sender
 name=Bqckup
+; Sender address / SMTP username
 email=
+; SMTP password. Leave empty for servers that need no authentication (e.g. local Mailpit/Mailhog)
 password=
+; SMTP host and port (Gmail: smtp.gmail.com / 587, local Mailpit: 127.0.0.1 / 1025)
 host=smtp.gmail.com
 port=587
-; Encryption: tls or ssl
+; Encryption: tls, ssl, or leave empty for none
 encryption=tls
 
 [webhooks]

--- a/bqckup.cnf.example
+++ b/bqckup.cnf.example
@@ -23,11 +23,24 @@ enabled=0
 ; reports will be sent at the end of every month, make sure notification are enabled
 monthly_report_enabled=0
 
-; Currently Only Discord is supported
+; Notification channels, comma separated. Supported: discord, email
 channel=discord
 
 ; Webhook URL
 discord_webhook_url=
+
+; Recipient address for the email channel (comma separated for multiple)
+email_to=
+
+[email]
+; SMTP sender settings, used when the `email` notification channel is enabled
+name=Bqckup
+email=
+password=
+host=smtp.gmail.com
+port=587
+; Encryption: tls or ssl
+encryption=tls
 
 [webhooks]
 after_backup_completed=

--- a/classes/bqckup.py
+++ b/classes/bqckup.py
@@ -25,6 +25,7 @@ from helpers.file import remove_folder
 from hashlib import sha256
 from pathlib import Path
 from lib.notifications.discord import send_notification
+from lib.notifications.email import send_notification as send_email_notification
 from helpers.datetime import time_since, get_today, difference_in_days, interval_in_number
 from helpers.network import get_server_ip
 from rich import print
@@ -98,6 +99,7 @@ class Bqckup:
             return
 
         send_notification(payload)
+        send_email_notification(payload)
         NotificationLog().create(hash=hashed_payload, sent_at=int(time.time()))
             
     def validate_config(self, name: str) -> bool:

--- a/classes/database.py
+++ b/classes/database.py
@@ -78,17 +78,8 @@ class Database:
         db_port: int = 3306,
         log_dir: Optional[str] = None,
     ) -> None:
-        log_file = Path(log_dir) / "database.log" if log_dir else DATABASE_LOG
-
-        if not log_file.parent.exists():
-            log_file.parent.mkdir(parents=True, exist_ok=True)
-
-        label = (
-            f"{db_user}@{db_host}:{db_port}/{db_name}"
-            if self.type != "sqlite"
-            else f"sqlite:{db_name}"
-        )
-
+        # Resolve the command first so an unsupported type fails fast,
+        # before creating any log directory or file.
         if self.type == "mysql":
             command = self._get_mysql_command(
                 db_user, db_password, db_name, db_host, db_port
@@ -104,7 +95,23 @@ class Database:
         else:
             raise DatabaseException(f"Unsupported database type: {self.type}")
 
-        with open(log_file, "ab") as log:
+        label = (
+            f"{db_user}@{db_host}:{db_port}/{db_name}"
+            if self.type != "sqlite"
+            else f"sqlite:{db_name}"
+        )
+
+        log_file = Path(log_dir) / "database.log" if log_dir else DATABASE_LOG
+
+        # Don't let an unwritable log location abort the backup itself.
+        try:
+            log_file.parent.mkdir(parents=True, exist_ok=True)
+            log = open(log_file, "ab")
+        except OSError as e:
+            print(f"[yellow]Cannot write export log to {log_file} ({e}); continuing without file log[/yellow]")
+            log = open(os.devnull, "ab")
+
+        with log:
             now = datetime.now()
             log.write(f"Database export {label} > {output} at {now}\n".encode())
             log.flush()

--- a/classes/mail.py
+++ b/classes/mail.py
@@ -8,25 +8,28 @@ class Mail:
         self.email = Config().read('email', 'email')
         self.name = Config().read('email', 'name')
         self.password = Config().read('email', 'password')
-        self.mailer = Config().read('email', 'mailer')
         self.host = Config().read('email', 'host')
         self.encryption = Config().read('email', 'encryption')
         self.port = Config().read('email', 'port')
 
     def send(self, subject: str, to: list, content: str):
         try:
-            import jinja2, emails
+            import emails
             message = emails.html(html=content, subject=subject, mail_from=(self.name, self.email))
-            smtp={
+            encryption = (self.encryption or '').lower()
+            smtp = {
                 'host': self.host,
-                'port': self.port,
-                'user': self.email,
-                'password': self.password,
-                'tls': self.encryption.lower() == 'tls',
+                'port': int(self.port) if self.port else 25,
+                'tls': encryption == 'tls',
+                'ssl': encryption == 'ssl',
             }
-            message.send(
-                to=to,
-                smtp=smtp,
-            )
+            # only authenticate when a password is set; local test servers (Mailpit/Mailhog) need no auth
+            if self.password:
+                smtp['user'] = self.email
+                smtp['password'] = self.password
+
+            response = message.send(to=to, smtp=smtp)
+            if response is None or not response.success:
+                raise MailExceptoin(f"SMTP delivery failed: {getattr(response, 'error', response)}")
         except Exception as e:
             raise MailExceptoin(str(e))

--- a/lib/notifications/discord.py
+++ b/lib/notifications/discord.py
@@ -10,7 +10,11 @@ sender = {
 def send_notification(data):
     if Config().read('notification', 'enabled') != '1':
         return
-    
+
+    channel = Config().read('notification', 'channel', default='discord', print_error=False) or 'discord'
+    if 'discord' not in [c.strip().lower() for c in channel.split(',')]:
+        return
+
     try:
         data = {**sender, **data}
         req.post(Config().read('notification', 'discord_webhook_url'), json=data)        

--- a/lib/notifications/email.py
+++ b/lib/notifications/email.py
@@ -1,0 +1,59 @@
+from classes.config import Config
+from classes.mail import Mail
+
+
+def _channels():
+    channel = Config().read('notification', 'channel', default='', print_error=False) or ''
+    return [c.strip().lower() for c in channel.split(',') if c.strip()]
+
+
+def _render_html(embeds):
+    parts = []
+    for embed in embeds:
+        title = embed.get('title') or 'Bqckup Notification'
+        parts.append(f"<h2 style='margin:0 0 8px'>{title}</h2>")
+
+        description = embed.get('description')
+        if description:
+            parts.append(f"<p style='white-space:pre-line'>{description}</p>")
+
+        rows = ''
+        for field in embed.get('fields') or []:
+            name = field.get('name') or ''
+            value = field.get('value') or ''
+            rows += (
+                "<tr>"
+                f"<td style='padding:4px 12px 4px 0;font-weight:bold;vertical-align:top'>{name}</td>"
+                f"<td style='padding:4px 0;white-space:pre-line'>{value}</td>"
+                "</tr>"
+            )
+        if rows:
+            parts.append(f"<table style='border-collapse:collapse'>{rows}</table>")
+
+        footer = (embed.get('footer') or {}).get('text')
+        if footer:
+            parts.append(f"<p style='color:#888;font-size:12px;margin-top:16px'>{footer}</p>")
+
+    return "<div style='font-family:Arial,sans-serif;color:#222'>" + ''.join(parts) + "</div>"
+
+
+def send_notification(payload):
+    if Config().read('notification', 'enabled') != '1':
+        return
+
+    if 'email' not in _channels():
+        return
+
+    recipient = Config().read('notification', 'email_to')
+    if not recipient:
+        print("Email notification enabled but `email_to` is not set in bqckup.cnf")
+        return
+
+    to = [addr.strip() for addr in recipient.split(',') if addr.strip()]
+
+    try:
+        embeds = payload.get('embeds') or []
+        subject = embeds[0].get('title') if embeds else 'Bqckup Notification'
+        Mail().send(subject=subject, to=to, content=_render_html(embeds))
+    except Exception as e:
+        print(f"Failed to send email notification: {e}")

--- a/lib/notifications/email.py
+++ b/lib/notifications/email.py
@@ -1,5 +1,10 @@
+from html import escape
 from classes.config import Config
 from classes.mail import Mail
+
+LOGO_URL = "https://avatars.githubusercontent.com/u/108687982?s=200&v=4"
+BRAND_COLOR = "#0A1A4F"   # navy from the Bqckup logo
+ACCENT_COLOR = "#F5B820"  # gold from the Bqckup logo
 
 
 def _channels():
@@ -7,34 +12,107 @@ def _channels():
     return [c.strip().lower() for c in channel.split(',') if c.strip()]
 
 
+def _hex_color(color):
+    """Convert a Discord-style integer color into a CSS hex string."""
+    try:
+        return "#{:06X}".format(int(color) & 0xFFFFFF)
+    except (TypeError, ValueError):
+        return ACCENT_COLOR
+
+
+def _render_embed(embed):
+    accent = _hex_color(embed.get('color'))
+    title = escape(str(embed.get('title') or 'Bqckup Notification'))
+
+    blocks = [
+        # Status banner using the embed color
+        f"<tr><td style='padding:0'>"
+        f"<table role='presentation' width='100%' cellpadding='0' cellspacing='0' style='border-collapse:collapse'>"
+        f"<tr><td style='background:{accent};height:6px;line-height:6px;font-size:6px'>&nbsp;</td></tr>"
+        f"</table></td></tr>",
+        # Title
+        f"<tr><td style='padding:28px 32px 0 32px'>"
+        f"<h1 style='margin:0;font-size:22px;line-height:1.3;color:#1a1a2e;font-family:Arial,Helvetica,sans-serif'>{title}</h1>"
+        f"</td></tr>",
+    ]
+
+    description = embed.get('description')
+    if description:
+        blocks.append(
+            f"<tr><td style='padding:12px 32px 0 32px;font-size:14px;line-height:1.6;"
+            f"color:#52525b;white-space:pre-line;font-family:Arial,Helvetica,sans-serif'>"
+            f"{escape(str(description))}</td></tr>"
+        )
+
+    rows = ''
+    for field in embed.get('fields') or []:
+        name = escape(str(field.get('name') or ''))
+        value = escape(str(field.get('value') or ''))
+        if not name and not value:
+            continue
+        rows += (
+            "<tr>"
+            f"<td style='padding:10px 16px;border-bottom:1px solid #ececf1;font-size:13px;"
+            f"font-weight:bold;color:#1a1a2e;white-space:nowrap;vertical-align:top;width:38%'>{name}</td>"
+            f"<td style='padding:10px 16px;border-bottom:1px solid #ececf1;font-size:13px;"
+            f"color:#3f3f46;white-space:pre-line;word-break:break-word'>{value}</td>"
+            "</tr>"
+        )
+    if rows:
+        blocks.append(
+            f"<tr><td style='padding:20px 32px 0 32px'>"
+            f"<table role='presentation' width='100%' cellpadding='0' cellspacing='0' "
+            f"style='border-collapse:collapse;border:1px solid #ececf1;border-radius:8px;overflow:hidden'>"
+            f"{rows}</table></td></tr>"
+        )
+
+    footer = (embed.get('footer') or {}).get('text')
+    if footer:
+        blocks.append(
+            f"<tr><td style='padding:20px 32px 0 32px;font-size:12px;line-height:1.5;"
+            f"color:#a1a1aa;font-family:Arial,Helvetica,sans-serif'>{escape(str(footer))}</td></tr>"
+        )
+
+    return ''.join(blocks)
+
+
 def _render_html(embeds):
-    parts = []
-    for embed in embeds:
-        title = embed.get('title') or 'Bqckup Notification'
-        parts.append(f"<h2 style='margin:0 0 8px'>{title}</h2>")
+    body = ''.join(_render_embed(embed) for embed in embeds)
 
-        description = embed.get('description')
-        if description:
-            parts.append(f"<p style='white-space:pre-line'>{description}</p>")
-
-        rows = ''
-        for field in embed.get('fields') or []:
-            name = field.get('name') or ''
-            value = field.get('value') or ''
-            rows += (
-                "<tr>"
-                f"<td style='padding:4px 12px 4px 0;font-weight:bold;vertical-align:top'>{name}</td>"
-                f"<td style='padding:4px 0;white-space:pre-line'>{value}</td>"
-                "</tr>"
-            )
-        if rows:
-            parts.append(f"<table style='border-collapse:collapse'>{rows}</table>")
-
-        footer = (embed.get('footer') or {}).get('text')
-        if footer:
-            parts.append(f"<p style='color:#888;font-size:12px;margin-top:16px'>{footer}</p>")
-
-    return "<div style='font-family:Arial,sans-serif;color:#222'>" + ''.join(parts) + "</div>"
+    return f"""\
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f4f5f7;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f5f7;padding:32px 0;">
+    <tr><td align="center">
+      <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width:600px;max-width:600px;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+        <!-- Header / brand -->
+        <tr><td style="background:{BRAND_COLOR};padding:22px 32px;">
+          <table role="presentation" cellpadding="0" cellspacing="0"><tr>
+            <td style="vertical-align:middle;padding-right:12px;">
+              <img src="{LOGO_URL}" width="40" height="40" alt="Bqckup" style="display:block;border-radius:10px;background:#ffffff;">
+            </td>
+            <td style="vertical-align:middle;">
+              <span style="font-size:19px;font-weight:bold;color:#ffffff;font-family:Arial,Helvetica,sans-serif;letter-spacing:0.3px;">Bq<span style="color:{ACCENT_COLOR};">c</span>kup</span>
+            </td>
+          </tr></table>
+        </td></tr>
+        <!-- Gold accent line -->
+        <tr><td style="background:{ACCENT_COLOR};height:3px;line-height:3px;font-size:3px;">&nbsp;</td></tr>
+        <!-- Content -->
+        {body}
+        <!-- Spacer -->
+        <tr><td style="padding:24px 32px 0 32px;"></td></tr>
+        <!-- Footer -->
+        <tr><td style="padding:20px 32px;border-top:1px solid #ececf1;font-size:12px;line-height:1.5;color:#a1a1aa;font-family:Arial,Helvetica,sans-serif;">
+          Sent automatically by <a href="https://bqckup.com" style="color:{BRAND_COLOR};text-decoration:none;font-weight:bold;">Bqckup</a> &middot; Backup and forget!
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>"""
 
 
 def send_notification(payload):

--- a/lib/notifications/email.py
+++ b/lib/notifications/email.py
@@ -20,8 +20,19 @@ def _hex_color(color):
         return ACCENT_COLOR
 
 
+def _muted(hex_color):
+    """Tone down a bright/neon color by blending it toward a soft slate."""
+    h = hex_color.lstrip('#')
+    try:
+        r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+    except (ValueError, IndexError):
+        return hex_color
+    mix = lambda c: int(c * 0.6 + 0x5A * 0.4)
+    return "#{:02X}{:02X}{:02X}".format(mix(r), mix(g), mix(b))
+
+
 def _render_embed(embed):
-    accent = _hex_color(embed.get('color'))
+    accent = _muted(_hex_color(embed.get('color')))
     title = escape(str(embed.get('title') or 'Bqckup Notification'))
 
     blocks = [
@@ -94,12 +105,10 @@ def _render_html(embeds):
               <img src="{LOGO_URL}" width="40" height="40" alt="Bqckup" style="display:block;border-radius:10px;background:#ffffff;">
             </td>
             <td style="vertical-align:middle;">
-              <span style="font-size:19px;font-weight:bold;color:#ffffff;font-family:Arial,Helvetica,sans-serif;letter-spacing:0.3px;">Bq<span style="color:{ACCENT_COLOR};">c</span>kup</span>
+              <span style="font-size:19px;font-weight:bold;color:#ffffff;font-family:Arial,Helvetica,sans-serif;letter-spacing:0.3px;">Bqckup</span>
             </td>
           </tr></table>
         </td></tr>
-        <!-- Gold accent line -->
-        <tr><td style="background:{ACCENT_COLOR};height:3px;line-height:3px;font-size:3px;">&nbsp;</td></tr>
         <!-- Content -->
         {body}
         <!-- Spacer -->

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-Login
 Flask-WTF
 gunicorn
 hurry.filesize
-mysql-connector-python==8.0.20
+mysql-connector-python==8.0.21
 psycopg2-binary
 peewee
 pyinstaller


### PR DESCRIPTION
# Description
This pull request adds support for email notifications alongside existing Discord notifications, and introduces configuration options for both channels. The notification system is now more flexible, allowing users to select one or both channels and configure SMTP settings for email delivery. The main changes are grouped below:


* Added support for sending notifications via email
* Extended the `bqckup.cnf.example` configuration file to include options for enabling/disabling notifications, selecting notification channels (`discord`, `email`, or both), and specifying SMTP settings for email notifications.

<img width="1148" height="747" alt="image" src="https://github.com/user-attachments/assets/049cf559-4b9c-4777-aecb-eae5b086cc8b" />
<img width="1163" height="558" alt="image" src="https://github.com/user-attachments/assets/040496c5-b1ae-46c0-8c9a-118618ad08a1" />